### PR TITLE
Specification for generators/ directory.

### DIFF
--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -7,7 +7,9 @@ sort: 3
 ## Typical example
 
 ```yaml
+# This solution will be used to create the answer for test cases where only the input was specified.
 solution: /submissions/accepted/author.cpp
+# This is optional and is used to generate a graphical representation of the test case input/answere.
 visualizer: /visualizers/visualizer {name}
 
 data:
@@ -67,12 +69,12 @@ random_salt: abcd
 # We support three types of generators:
 # - Standalone files, like generators/a.cpp, generators/b.py, ..., which will
 #   be compiled if required and run the same way as submissions.
-# - Directories, like
+# - Directories, like generators/gen containing files:
 #   - generators/gen/tree.cpp
 #   - generators/gen/lib.h
 #   This will be compiled and run the same way as directory validators. Build
 #   and run scripts may be used.
-# - 'implicit' generators whose dependencies are specified in the generators:
+# - 'implicit' generators whose dependencies are specified in the `generators:`
 #   key below. The dependencies may refer to any files relative to generators/.
 #   The generator will be built and run as if they formed a separate directory.
 #   The first item in the list will be used as entry point.
@@ -80,10 +82,10 @@ random_salt: abcd
 #   - generators/tree/tree.py
 #   - generators/tree/lib.py
 #
-# When a generator is used as a command to generate a .in file, we first check
-# if the name is a key in the generators: dictionary below. If that is the case,
-# the corresponding generator is used. If not, we will use the file/directory
-# generator in the generator/ directory directly.
+# For each generator name specified in a command to generate a .in
+# file, we first check if this name is a key in the `generators:` dictionary below. If so,
+# the corresponding generator is used. If not, we will use the generator with that
+# file/directory name in the `generators/` directory directly.
 generators:
 # A generator that depends on two files, lib.py and tree.py, directly in the
 # generators directory.
@@ -120,8 +122,9 @@ data:
     data:
       '1': stdout.py 1  # prints `1` to stdout, which is piped to 1.in
 
-# To indicate a manual testcase, specify it with an empty value.
-# Prefer specifying a path to a .in file as below.
+# To indicate a manual testcase already present in the corresponding directory, specify it with an empty value.
+# Prefer specifying a path to a .in file as in case `3` below.
+# E.g., this indicates that `data/sample/2.in` (and optionally `data/sample/2.ans`) are existing non-generated files.
       '2':
 # Any key that matches the glob `*.in` is a manual testcase that will be copied
 # from the given directory into the target testcase. The given directory
@@ -129,8 +132,8 @@ data:
 # If a solution is specified, .ans files will be generated for manual cases
 # that don't provide a .ans.
       '3': manual_cases/sample/3.in
-# Every testcase must be listed.
-# TOOLING: may allow this and print a warning.
+# Every testcase present in the directory must be listed.
+# TOOLING: may still allow unlisted testcases and warn about them.
      #'4':
 
   secret:
@@ -139,14 +142,15 @@ data:
 
 # Types of generator programs.
       '01': stdout.py  3   # stdout of the command is written to 01.in.
-      '02': stdout.cpp 4   # c++ is compiled as for validators
+      '02': stdout.cpp 4   # c++ is compiled as for validators, and the resulting binary is run with argumetn `4`.
       '03': dir 5          # directories are OK as for validators
       '04': tree 5         # keys from the global generators: dictionary may also be used.
       '05': a 5            # idem
 
-# Arguments are split on white space: this will pass two arguments: `"a` and `b"`.
+# Arguments are split on white space: this will pass two arguments: `"a` and `b"`, so probably not what is intended.
       06-string: stdout.py "a b"
-# This will pass two arguments: a and b
+# This will pass two arguments: a and b, using YAML multiline string syntax.
+# Passing arguments containing whitespace is not possible.
       07-string: |
         stdout.py
         a
@@ -166,19 +170,25 @@ data:
      #01-second: stdout.py 6                     # Collision with rule 01 above.
      #hard_cases_group-01: stdout.py 7           # Collision with hard_cases_group below.
 
-# {name} may be used to reference the current test case name/dictionary key.
+# {name} may be used to reference the path to the current test case/dictionary.
+# The value of {name} is unspecified, and it may point to a file outside of the
+# current working directory.
+# 
 #
 # Commands are allowed to write files in the current working directory as long
 # as they do not overwrite existing files. Files starting with the current
 # {name} may always be written to.
 # Commands may only read files that they have written themselves.
 #
-# Any written files matching {name}.ext where ext is a know extension in
+# Any written files matching `{name}.<ext>` where `<ext>` is a know extension in
 # .in, .ans, .hint, .desc, .png, .jpg, ..svg
 # will be saved.
 #
-# In case a program writes {name}.in, stdout will be ignored.
+# In case a generator program writes {name}.in, stdout will be ignored.
 # In case {name}.in is not created, stdout will be used as input.
+#
+# The generator below generates and writes both {name}.in and {name}.ans, and
+# the optionally specified `solution:` will not be called.
       '12': write_in_and_ans.py {name}
 
 
@@ -192,9 +202,8 @@ data:
         random_salt: '123'
 
 
-
 # Introduce a testgroup by adding a dictionary with `type: directory` set.
-# The top-level is always assumed to be a directory.
+# The top-level `data:` key is always assumed to be a directory.
       hard_cases_group:
         type: directory
 
@@ -225,7 +234,7 @@ data:
               data:
                 - c: stdout.py c
                   d: stdout.py d
-# This is forbidden because data: dictionaries may not appear within data: lists.
+# This is forbidden because the parent `data:` key in `hard_cases_group` is a (numbered) list, and (unnumbered) dictionaries are not allowed to appear within (numbered) lists.
              #data:
              #  c: stdout.py c
           - e: stdout.py e
@@ -235,7 +244,10 @@ data:
           - i: stdout.py i
           - j: stdout.py j
           - k: stdout.py k
-          - l: stdout.py l
+          # {name} May also be used in numbered lists.
+          # It is unspecified whether the {name} passed as argument is `l` or
+          # `11-l` or something else.
+          - l: stdout.py {name}
 
 # The above data: list is equivalent to the map:
        #data:

--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -222,7 +222,10 @@ data:
 # the given name is not empty). All items in a given dictionary will get the
 # same number. Use a list of 1-item dictionaries for incremental numbering.
 #
-# Any testgroup inside a list must contain a list object as data:.
+# Any testgroup inside a list must contain a list object as `data:`. Thus, if
+# in a directory/testgroup the test cases are numbered (i.e. `data:`) contains
+# a list), then `data:` must contain a list in all directories/testgroups below
+# it.
 #
 # Numbering is per directory. Testcases/testgroups are ordered by the order of lists
 # and alphabetical for dictionaries.

--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -175,7 +175,7 @@ data:
 # The value of {name} is unspecified, and it may point to a file outside of the
 # current working directory.
 #
-# Commands are allowed to only allowed to read and write files of the form
+# Commands are only allowed to read and write files of the form
 # {name}.<ext>, where <ext> is a known file extension in 
 # .in, .ans, .hint, .desc, .png, .jpg, .svg.
 # Any such written files will be saved.

--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -142,7 +142,7 @@ data:
 
 # Types of generator programs.
       '01': stdout.py  3   # stdout of the command is written to 01.in.
-      '02': stdout.cpp 4   # c++ is compiled as for validators, and the resulting binary is run with argumetn `4`.
+      '02': stdout.cpp 4   # c++ is compiled as for validators, and the resulting binary is run with argument `4`.
       '03': dir 5          # directories are OK as for validators
       '04': tree 5         # keys from the global generators: dictionary may also be used.
       '05': a 5            # idem
@@ -234,7 +234,9 @@ data:
               data:
                 - c: stdout.py c
                   d: stdout.py d
-# This is forbidden because the parent `data:` key in `hard_cases_group` is a (numbered) list, and (unnumbered) dictionaries are not allowed to appear within (numbered) lists.
+# Replacing the `data:` object above (a list) with the following (a dictionary)
+# is forbidden because the parent directory (`hard_cases_group`) is numbered, and
+# unnumbered dictionaries are not allowed to appear within numbered directories.
              #data:
              #  c: stdout.py c
           - e: stdout.py e

--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -170,22 +170,18 @@ data:
      #01-second: stdout.py 6                     # Collision with rule 01 above.
      #hard_cases_group-01: stdout.py 7           # Collision with hard_cases_group below.
 
-# {name} may be used to reference the path to the current test case/dictionary.
+# {name} may be used to reference the current test case.
+# It is equal to the name of the testcase, including the number if this is a numbered testcases.
 # The value of {name} is unspecified, and it may point to a file outside of the
 # current working directory.
-# 
 #
-# Commands are allowed to write files in the current working directory as long
-# as they do not overwrite existing files. Files starting with the current
-# {name} may always be written to.
-# Commands may only read files that they have written themselves.
+# Commands are allowed to only allowed to read and write files of the form
+# {name}.<ext>, where <ext> is a known file extension in 
+# .in, .ans, .hint, .desc, .png, .jpg, .svg.
+# Any such written files will be saved.
 #
-# Any written files matching `{name}.<ext>` where `<ext>` is a know extension in
-# .in, .ans, .hint, .desc, .png, .jpg, ..svg
-# will be saved.
-#
-# In case a generator program writes {name}.in, stdout will be ignored.
-# In case {name}.in is not created, stdout will be used as input.
+# In case a generator program writes {name}.in, its stdout will be ignored.
+# In case {name}.in is not created, stdout will be used as the input for the testcase.
 #
 # The generator below generates and writes both {name}.in and {name}.ans, and
 # the optionally specified `solution:` will not be called.
@@ -250,8 +246,7 @@ data:
           - j: stdout.py j
           - k: stdout.py k
           # {name} May also be used in numbered lists.
-          # It is unspecified whether the {name} passed as argument is `l` or
-          # `11-l` or something else.
+          # In this case, it will be equal to `11-l`.
           - l: stdout.py {name}
 
 # The above data: list is equivalent to the map:

--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -1,0 +1,261 @@
+---
+sort: 3
+---
+
+# Generators.yaml
+
+## Typical example
+
+```yaml
+solution: /submissions/accepted/author.cpp
+visualizer: /visualizers/visualizer {name}
+
+data:
+    sample:
+        type: directory
+        # No .ans files are generated for the samples.
+        solution:
+        data:
+            '1':
+            '2':
+            '3':
+    secret:
+        type: directory
+        data:
+            # Written to data/secret/1-small-tree.{in,ans}.
+            # Calls the tree.py script in generators/ with the given arguments.
+            - small-tree: tree.py 10 {seed}
+            # Written to 2-medium-tree.
+            - medium-tree: tree.py 100 {seed:1}
+            # Written to 3-medium-tree.
+            - medium-tree: tree.py 100 {seed:2}
+            - large-tree: tree.py 1000000 {seed}
+            - medium-graph: graph.py 100 20 {seed}
+            - large-graph: graph.py 1000000 2000000 {seed}
+            # Points to generators/manual/large.in.
+            - manual-large: manual/large.in
+```
+
+## Commented maximal example
+
+```yaml
+# The solution is used to generate a .ans for each generated .in which doesn't
+# yet have a corresponding .ans. If there are generators that don't write a .ans
+# file themselves, this must be specified.
+# This should read the input from stdin and write to stdout.
+#
+# This must be the absolute path to the solution, starting in the problem root.
+#
+# TOOLING: may pick a default if not specified, but should raise a warning.
+solution: /submissions/accepted/sol.py
+
+# The visualizer is used when no suitable image was generated already.
+# This should read {name}.in and/or {name}.ans from the current working
+# directory, and write {name}.ext for an extension in:
+# .png, .jpg, .svg
+#
+# This must be the absolute path, starting in the problem root.
+#
+# TOOLING: may provide a flag to make running this optional, as it can be slow
+# and usually isn't required.
+visualizer: /visualizers/asy.py {name}
+
+# Optionally, a salt for generating the {seed} variables. Will be prepended to
+# the command being run.
+random_salt: abcd
+
+# We support three types of generators:
+# - Standalone files, like generators/a.cpp, generators/b.py, ..., which will
+#   be compiled if required and run the same way as submissions.
+# - Directories, like
+#   - generators/gen/tree.cpp
+#   - generators/gen/lib.h
+#   This will be compiled and run the same way as directory validators. Build
+#   and run scripts may be used.
+# - 'implicit' generators whose dependencies are specified in the generators:
+#   key below. The dependencies may refer to any files relative to generators/.
+#   The generator will be built and run as if they formed a separate directory.
+#   The first item in the list will be used as entry point.
+#   E.g. the first example below would be equivalent to the two files
+#   - generators/tree/tree.py
+#   - generators/tree/lib.py
+#
+# When a generator is used as a command to generate a .in file, we first check
+# if the name is a key in the generators: dictionary below. If that is the case,
+# the corresponding generator is used. If not, we will use the file/directory
+# generator in the generator/ directory directly.
+generators:
+# A generator that depends on two files, lib.py and tree.py, directly in the
+# generators directory.
+  tree:
+    - tree.py
+    - lib.py
+# Another generator that also depends on the same lib.py.
+  graph:
+    - graph.py
+    - lib.py
+# This also works for other languages.
+  a:
+    - a.cpp
+    - a.h
+# Single-file generators may be specified, but can also be referred to as
+# b.cpp directly.
+  b:
+    - b.cpp
+# It is allowed, but not required, to explicitly list single-file generators
+# as well. It is allowed to reuse the same name, but introducing a new name is
+# also fine.
+  c.py:
+    - c.py
+    - lib.py
+
+# The data: keyword contains the list of test cases and test data groups.
+# Note that this is different from the data/ directory, which is where the keys
+# of this top-level data: dictionary will be written.
+data:
+  # Introduce the `sample` directory.
+  sample:
+    type: directory
+    solution: # empty to disable generating .ans files here
+    data:
+      '1': stdout.py 1  # prints `1` to stdout, which is piped to 1.in
+
+# To indicate a manual testcase, specify it with an empty value.
+# Prefer specifying a path to a .in file as below.
+      '2':
+# Any key that matches the glob `*.in` is a manual testcase that will be copied
+# from the given directory into the target testcase. The given directory
+# must not start with a / and will be relative to generators/.
+# If a solution is specified, .ans files will be generated for manual cases
+# that don't provide a .ans.
+      '3': manual_cases/sample/3.in
+# Every testcase must be listed.
+# TOOLING: may allow this and print a warning.
+     #'4':
+
+  secret:
+    type: directory
+    data:
+
+# Types of generator programs.
+      '01': stdout.py  3   # stdout of the command is written to 01.in.
+      '02': stdout.cpp 4   # c++ is compiled as for validators
+      '03': dir 5          # directories are OK as for validators
+      '04': tree 5         # keys from the global generators: dictionary may also be used.
+      '05': a 5            # idem
+
+# Arguments are split on white space: this will pass two arguments: `"a` and `b"`.
+      06-string: stdout.py "a b"
+# This will pass two arguments: a and b
+      07-string: |
+        stdout.py
+        a
+        b
+
+# The regex \{seed(:[0-9]+)?\} (e.g. {seed} or {seed:1}) anywhere in the argument
+# string will be replaced by an integer hash of the entire command in [0, 2^31).
+# The regex may match at most once.
+# int(hashlib.sha512((random_salt+command).encode('utf-8')).hexdigest(), 16)%(2**31)
+      08-random-1:    stdout.py {seed}
+     #09-random-1a:   stdout.py {seed}           # It's an error to use the exact same command twice.
+      10-random-2:    stdout.py {seed:2}         # Different seed, because of extra `2`
+      11-random-3:    stdout.py seed={seed:2}    # Different seed, because command isn't the same.
+     #11-random-4:    stdout.py {seed} {seed:2}  # Not allowed because the regex matches twice.
+
+# No key (testcase or testgroup) may be a prefix of another key.
+     #01-second: stdout.py 6                     # Collision with rule 01 above.
+     #hard_cases_group-01: stdout.py 7           # Collision with hard_cases_group below.
+
+# {name} may be used to reference the current test case name/dictionary key.
+#
+# Commands are allowed to write files in the current working directory as long
+# as they do not overwrite existing files. Files starting with the current
+# {name} may always be written to.
+# Commands may only read files that they have written themselves.
+#
+# Any written files matching {name}.ext where ext is a know extension in
+# .in, .ans, .hint, .desc, .png, .jpg, ..svg
+# will be saved.
+#
+# In case a program writes {name}.in, stdout will be ignored.
+# In case {name}.in is not created, stdout will be used as input.
+      '12': write_in_and_ans.py {name}
+
+
+# To override the global/testgroup configuration on a per-testcase basis,
+# a dictionary may be used. This allows the solution: and visualizer: keys,
+# as well as the input: key which contains the command to execute.
+      13_no_visualizer:
+        input: large_case_generator.py 1000000
+        solution: /generators/gnu_multi_precision.cpp
+        visualizer:                         # Empty to disable the visualizer here.
+        random_salt: '123'
+
+
+
+# Introduce a testgroup by adding a dictionary with `type: directory` set.
+# The top-level is always assumed to be a directory.
+      hard_cases_group:
+        type: directory
+
+# Directories may contain a testdata.yaml that will be written as specified.
+        testdata.yaml:
+          on_reject: break
+          accept_score: 25
+          range: 0 25
+          grader_flags: min
+
+# To enable automatic numbering of testcases, data: may also contain a list of
+# dictionaries instead of a single dictionary. In this case, testcases and/or
+# groups will be numbered in the order they appear, starting at 1. The system
+# will determine the required number of digits to use and numbers will be
+# zero-padded accordingly, using a dash as separator from the given name (when
+# the given name is not empty). All items in a given dictionary will get the
+# same number. Use a list of 1-item dictionaries for incremental numbering.
+#
+# Any testgroup inside a list must contain a list object as data:.
+#
+# Numbering is per directory. Testcases/testgroups are ordered by the order of lists
+# and alphabetical for dictionaries.
+        data:
+          - a: stdout.py a
+            b: stdout.py b
+          - testgroup:
+              type: directory
+              data:
+                - c: stdout.py c
+                  d: stdout.py d
+# This is forbidden because data: dictionaries may not appear within data: lists.
+             #data:
+             #  c: stdout.py c
+          - e: stdout.py e
+          - f: stdout.py f
+          - g: stdout.py g
+          - h: stdout.py h
+          - i: stdout.py i
+          - j: stdout.py j
+          - k: stdout.py k
+          - l: stdout.py l
+
+# The above data: list is equivalent to the map:
+       #data:
+       #  01-a: stdout.py a
+       #  01-b: stdout.py b
+       #  02-testgroup:
+       #    type: directory
+       #    data:
+       #      1-c: stdout.py c
+       #      1-d: stdout.py d
+       #  03-e: stdout.py e
+       #  04-f: stdout.py f
+       #  05-g: stdout.py g
+       #  06-h: stdout.py h
+       #  07-i: stdout.py i
+       #  08-j: stdout.py j
+       #  09-k: stdout.py k
+       #  10-l: stdout.py l
+
+# Unknown keys are allowed inside directory dictionaries for tooling-specific
+# extensions. This includes both the global scope and explicit directories with type: directory.
+unknown_key: tool_specific_config
+```

--- a/examples/generators.yaml.md
+++ b/examples/generators.yaml.md
@@ -73,7 +73,7 @@ random_salt: abcd
 #   - generators/gen/tree.cpp
 #   - generators/gen/lib.h
 #   This will be compiled and run the same way as directory validators. Build
-#   and run scripts may be used.
+#   and run scripts may be used, as explained in ../spec/problem_package_format#programs.
 # - 'implicit' generators whose dependencies are specified in the `generators:`
 #   key below. The dependencies may refer to any files relative to generators/.
 #   The generator will be built and run as if they formed a separate directory.

--- a/examples/problem.yaml.md
+++ b/examples/problem.yaml.md
@@ -4,7 +4,7 @@ permalink: /examples/problem_yaml
 ---
 # Problem.yaml
 
-Typical problem.yaml:
+## Typical problem.yaml
 
 ```yaml
 # Problem configuration
@@ -13,7 +13,7 @@ author: John von Judge
 rights_owner: ICPC
 ```
 
-Maximal problem.yaml:
+## Maximal problem.yaml
 
 ```yaml
 # Problem configuration

--- a/spec/generators.md
+++ b/spec/generators.md
@@ -5,7 +5,8 @@ sort: 3
 # Generators
 
 Generators are provided in the `generators/` directory and may be used to
-generate test cases.  If it is present, the file `generators/generators.yaml`
+generate test cases. 
+The file `generators/generators.yaml`, if present,
 specifies which testcases should be generated and which commands should be run
 to generate them.
 Please have a look at [**the generator examples**](../examples/generators.yaml) to quickly get a feeling of what a typical `generators.yaml` file looks like.
@@ -39,14 +40,14 @@ A **Directory** is a YAML dictionary with the following supported keys.
 * `solution`
     * Type: **Command**
     * Optional invocation of a solution to be used to generate `.ans` files in this directory and its children.
-      Set to empty to disable generating `.ans`.
+      Set to empty to disable generating `.ans` files.
       (Useful for e.g. the `data/samples/` directory.)
       This must be an absolute path relative to the problem root.
 
       Solutions must write the answer to standard output, or take the `{name}` argument and write the answer file directly.
 * `visualizer`
     * Type: **Command**
-    * Optional invocation of a visualizer to generate visualizations for each test case in this directory and its children.
+    * Optional invocation of a program to generate visualizations for each test case in this directory and its children.
       This must be an absolute path relative to the problem root. Set to empty to disable.
 
        _Visualizers should take the `{name}` argument and write to `{name}.ext` where `ext` is a supported image extension._
@@ -68,7 +69,7 @@ The root of the `generators.yaml` file is a **Directory** object with one option
 
       When this dictionary contains a name that is also a file in `generators/`, the version specified in the `generators` dictionary will have priority.
 
-      Generators specified in the `generators` dictionary are built by coping the list of files into a new directory, and then building the resulting program as usual. The first dependency listed will be used to determine the entry point.
+      Generators specified in the `generators` dictionary are built by coping the list of files into a new directory, and then building the resulting program as described in [programs](../spec/problem_package_format#programs). The first dependency listed will be used to determine the entry point.
       An example is [here](../examples/generators.yaml).
 
       Other generators are built as (file or directory) [programs](../spec/Problem_Format#Programs).
@@ -94,7 +95,7 @@ A **Command** is a string that specified how to invoke a generator. The form is:
 ```
 Generators are run from an unspecified working directory. _In particular, they must not assume that the working directory is either the directory of the target testcase (e.g. `data/secret`) or the directory of the program (e.g. `visualizers/my_visualizer/`)._
 
-Generators must be deterministic, i.e. always produce the same input file when give the same arguments.
+Generators must be deterministic, i.e. always produce the same input file when give the same arguments, but see the `{seed}` keyword below.
 
 Generators must be idempotent, i.e. running them multiple times should result in the same output as running them once.
 
@@ -102,11 +103,19 @@ Generators must be idempotent, i.e. running them multiple times should result in
 * The generator will be invoked with `<arguments>`.
   Arguments are separated by white space (space, tab, newline). Quoting white space is not supported.
   Two special values are available, that will be substituted before calling the generator.
-    * `{name}`: refers to the name of the testcase. The generator may read/write the files `{name}.<ext>`, where `<ext>` is a file extension recognised by the problem format. Reading or writing other files is not allowed.
+    * `{name}`: refers to the path (directory and name) of the testcase. The
+      generator may read/write the files `{name}.<ext>`, where `<ext>` is a
+      file extension recognized by the problem format. Reading or writing other
+      files is not allowed.
+
+      The value of `{name}` is otherwise unspecified: it may point to any
+      existing directory, and the basename of `{name}` does not
+      have to correspond to the actual test case name, as long as the
+      generator is able to read and write the necessary files.
 
       _Note that `{name}` does not have to be in the currently working directory,
       and may not be inside the `data/` directory._
-    * `{seed}` or `{seed:(0-9)+}`: will be replaced by a pseudo random seed deterministically generated from the generator invocation. Use `{seed:1}`, `{seed:2}`, ..., to use different seeds for multiple otherwise identical generator invocations.
+    * `{seed}` or `{seed:[0-9]+}`: will be replaced by a pseudo random seed deterministically generated from the generator invocation. Use `{seed:1}`, `{seed:2}`, ..., to use different seeds for multiple otherwise identical generator invocations.
 
 ## CUE specification.
 

--- a/spec/generators.md
+++ b/spec/generators.md
@@ -1,0 +1,160 @@
+---
+sort: 3
+---
+
+# Generators
+
+Generators are provided in the `generators/` directory and may be used to
+generate test cases.  If it is present, the file `generators/generators.yaml`
+specifies which testcases should be generated and which commands should be run
+to generate them.
+Please have a look at [**the generator examples**](../examples/generators.yaml) to quickly get a feeling of what a typical `generators.yaml` file looks like.
+
+When `generators/generators.yaml` is present, _all_ test cases in
+`data/{sample,secret}` must be mentioned by it. It is not allowed to generate
+some testcases while not mentioning others. Testcases must be explicitly
+listed as manually created to prevent this issue.
+
+Below are an explanation of the specification and a formal [CUE specification](#cue-specification).
+
+## Specification
+
+The three main object types are **Directory**, **Generator** and **Command**. The root of `generators.yaml` is a **Root Directory** which corresponds to the `data/` directory.
+
+Unknown keys are allowed and ignored.
+
+### **Directory**
+
+A **Directory** is a YAML dictionary with the following supported keys.
+
+* `type`
+    * Type: String
+    * Mandatory, **must** be set to `directory`.
+* `data`
+    * Type: (List of) dictionary mapping string to either **Directory** or **Generator**
+    * The test cases / test groups contained in this directory.
+      This may take one of two forms:
+        1.  A dictionary, where each key is the name of a test case/test group, and each value must be a **Directory** or **Generator**. _All names must be distinct, as required by the YAML specification._
+        1. A list of such dictionaries. In this case, testcases will be prefixed with zero padded 1-based integers in the order of the list. Items in the same dictionary will get the same number.
+* `solution`
+    * Type: **Command**
+    * Optional invocation of a solution to be used to generate `.ans` files in this directory and its children.
+      Set to empty to disable generating `.ans`.
+      (Useful for e.g. the `data/samples/` directory.)
+      This must be an absolute path relative to the problem root.
+
+      Solutions must write the answer to standard output, or take the `{name}` argument and write the answer file directly.
+* `visualizer`
+    * Type: **Command**
+    * Optional invocation of a visualizer to generate visualizations for each test case in this directory and its children.
+      This must be an absolute path relative to the problem root. Set to empty to disable.
+
+       _Visualizers should take the `{name}` argument and write to `{name}.ext` where `ext` is a supported image extension._
+* `testdata.yaml`
+    * Type: YAML object
+    * Optional configuration that will be copied to `testdata.yaml` in this directory.
+* `random_salt`
+    * Type: String
+    * Optional string that will be prepended to each command before computing its `{seed}`.
+      May be used to regenerate all random cases and to prevent predictable seeds.
+
+### **Root directory**
+The root of the `generators.yaml` file is a **Directory** object with one optional additional key:
+
+* `generators`
+    * Type: dictionary mapping string to list of string.
+    * A dictionary mapping generator names to a list of dependencies.
+      This must be used when using non-directory generators that depend on other files in the `generators/` directory. Each key of the dictionary is the name of a generator, and values must be lists of file paths relative to `generators/`.
+
+      When this dictionary contains a name that is also a file in `generators/`, the version specified in the `generators` dictionary will have priority.
+
+      Generators specified in the `generators` dictionary are built by coping the list of files into a new directory, and then building the resulting program as usual. The first dependency listed will be used to determine the entry point.
+      An example is [here](../examples/generators.yaml).
+
+      Other generators are built as (file or directory) [programs](../spec/Problem_Format#Programs).
+
+### **Generator**
+
+A **Generator** takes one of the following four types/forms:
+
+1. Null / empty
+    * An empty generator means that the testcase is a manual case and must not be modified or deleted by generator tooling. The corresponding `.in` file must be present in the `data/` directory. The corresponding `.ans` may be present, but may also be generated once from a given solution. Note that this form is discouraged. Prefer specifying a path to a `.in` file as below.
+1. String ending with `.in`
+    * A path to a `.in` file which must be relative to `generators/`. The `.in` file and corresponding files with known extensions will be copied to the specified location. If a `.ans` is not specified and a `solution` is provided, it will be used to generate the `.ans`.
+1. String not ending with `.in`,
+    * A **Command** to run a generator.
+1. Directory containing `type: testcase`
+    * The `input` key is the **Command** to use. Furthermore, the dictionary may contain the `solution`, `visualizer`, and `random_salt` keys similar to a **Directory** to specialize/override them for this testcase only.
+
+### **Command**
+
+A **Command** is a string that specified how to invoke a generator. The form is:
+```
+<generator_name> <arguments>
+```
+Generators are run from an unspecified working directory. _In particular, they must not assume that the working directory is either the directory of the target testcase (e.g. `data/secret`) or the directory of the program (e.g. `visualizers/my_visualizer/`)._
+
+Generators must be deterministic, i.e. always produce the same input file when give the same arguments.
+
+Generators must be idempotent, i.e. running them multiple times should result in the same output as running them once.
+
+* `<generator_name>` must either be a program (file/directory) in `generators/` or else a key in the top level `generators` dictionary.
+* The generator will be invoked with `<arguments>`.
+  Arguments are separated by white space (space, tab, newline). Quoting white space is not supported.
+  Two special values are available, that will be substituted before calling the generator.
+    * `{name}`: refers to the name of the testcase. The generator may read/write the files `{name}.<ext>`, where `<ext>` is a file extension recognised by the problem format. Reading or writing other files is not allowed.
+
+      _Note that `{name}` does not have to be in the currently working directory,
+      and may not be inside the `data/` directory._
+    * `{seed}` or `{seed:(0-9)+}`: will be replaced by a pseudo random seed deterministically generated from the generator invocation. Use `{seed:1}`, `{seed:2}`, ..., to use different seeds for multiple otherwise identical generator invocations.
+
+## CUE specification.
+
+Below is a formal [CUE](https://cuelang.org/docs/references/spec/) specification for the `generators.yaml` file with a root object `Generators`. Note that the `...` in `generator` and `directory` indicate that additional keys unknown to the spec are allowed. The `generator_reserved` and `directory_reserved` objects indicate keys that work only for `generator`/`directory` and should not be reused in other places.
+
+```
+command :: !="" & (=~"^[^{}]*(\\{(name|seed(:[0-9]+)?)\\}[^{}]*)*$")
+file_config :: {
+    solution?: command | null
+    visualizer?: command | null
+    random_salt?: string
+}
+generator :: command | {
+    type: "testcase"
+    input: command
+    file_config
+    directory_reserved
+    ...
+}
+data_dict :: {
+    [string]: directory | generator | null
+}
+directory :: {
+    type: "directory"
+    file_config
+    "testdata.yaml"?: {
+        ...
+    }
+    data?: data_dict | [...data_dict]
+    generator_reserved
+    ...
+}
+Generators :: {
+    generators?: {
+        [string]: [...string]
+    }
+    directory
+}
+
+generator_reserved :: {
+    input?: _|_
+    ...
+}
+directory_reserved :: {
+    data?: _|_
+    include?: _|_
+    "testdata.yaml"?: _|_
+    ...
+}
+```
+

--- a/spec/generators.md
+++ b/spec/generators.md
@@ -103,18 +103,11 @@ Generators must be idempotent, i.e. running them multiple times should result in
 * The generator will be invoked with `<arguments>`.
   Arguments are separated by white space (space, tab, newline). Quoting white space is not supported.
   Two special values are available, that will be substituted before calling the generator.
-    * `{name}`: refers to the path (directory and name) of the testcase. The
-      generator may read/write the files `{name}.<ext>`, where `<ext>` is a
+    * `{name}` is replaced by the name of the testcase, including the optional testcase number prefix. The
+      generator may read/write the files `{name}.<ext>` in the current working directory, where `<ext>` is a
       file extension recognized by the problem format. Reading or writing other
       files is not allowed.
 
-      The value of `{name}` is otherwise unspecified: it may point to any
-      existing directory, and the basename of `{name}` does not
-      have to correspond to the actual test case name, as long as the
-      generator is able to read and write the necessary files.
-
-      _Note that `{name}` does not have to be in the currently working directory,
-      and may not be inside the `data/` directory._
     * `{seed}` or `{seed:[0-9]+}`: will be replaced by a pseudo random seed deterministically generated from the generator invocation. Use `{seed:1}`, `{seed:2}`, ..., to use different seeds for multiple otherwise identical generator invocations.
 
 ## CUE specification.

--- a/spec/problem_format.md
+++ b/spec/problem_format.md
@@ -54,7 +54,7 @@ single directory. The name of the program, for the purpose of referring to it
 within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
-Validators and graders, but not submissions, in the form of a directory
+Validators, graders, and generators, but not submissions, in the form of a directory
 may include two POSIX-compliant scripts "build" and "run". Either both
 or none of these scripts must be included. If the scripts are present,
 then:

--- a/spec/problem_format.md
+++ b/spec/problem_format.md
@@ -597,47 +597,13 @@ modes are given, the last one is used. Their meaning are as follows.
 | `ignore_sample`                              | flag         | Must only be used on the root level. The first subresult (sample) will be ignored, the second subresult (secret) will be used, both verdict and score.                                                                                                                                                          |
 | `accept_if_any_accepted`                     | flag         | Verdict is accepted if any subresult is accepted, otherwise as specified by the verdict aggregation mode.                                                                                                                                                                                                       |
 </div>
-<div class="problemarchive">
 
+## Generators
 
-## <s>Generators</s>
-
-<s>
-
-Input generators are programs that generates input. They are
-provided in `generators/`.
-
-```note
-
-TODO: Add the new `generators.yaml` specification.
-```
-
-</s>
-
-### <s>Invocation</s>
-
-<s>
-
-A generator program must be an application (executable or
-interpreted) capable of being invoked with a command line call.
-
-The generators will be run with the test data directory (`data/`) as the
-working directory. The generator may read any existing files in that
-directory and should create any kind of test data file as defined in the
-test data section. The generator may not read or write anything outside
-the test data directory. The generators will be run in lexicographical
-order on name. If a specific order is desired a numbered prefix such as
-`00`, `01`, `02`, `03`, and so on, can be used.
-
-The generators must be deterministic, i.e. always produce the same input
-file when give the same arguments.
-
-The generators must be idempotent, i.e. running them multiple times
-should result in the same contents of the test data directory as running
-them once.
-
-</s>
-</div>
+Generators are used to generate test cases.
+They are provided in the `generators/` directory together with the file
+`generators/generators.yaml` which specifies how to invoke the generators to generate the test cases.
+This directory must adhere to the [**Generators specification**](./generators) .
 
 ## See also
 


### PR DESCRIPTION
Moved the example `generators.yaml` here, and made the spec we had written in the BAPCtools repo a bit nicer.

Specification: https://ragnargrootkoerkamp.nl/problem-package-format/generators/spec/generators.html
Updated this a bit, so PTAL. I made it a list of lists instead of a table for the `Directory` object since tables will make the description a bit too small I think.

Commented examples: https://ragnargrootkoerkamp.nl/problem-package-format/generators/examples/generators.yaml.html
This is unchanged from what we discussed in our meetings.

Description in main text: https://ragnargrootkoerkamp.nl/problem-package-format/generators/spec/problem_package_format#generators

@niemela @eldering @nickygerritsen @deboer-tim @clevengr (Not sure what the current membership status is here, so to be sure.)
FYI: @SuprDewd