### PR TITLE
update some broken links, rename files

### DIFF
--- a/spec/output_validators.md
+++ b/spec/output_validators.md
@@ -19,9 +19,9 @@ reporting back the results of validating:
 
 
 1.  The validator must give a judgment (see [Reporting a
-    judgment](#Reporting_a_judgment "wikilink")).
+    judgment](#reporting-a-judgment "wikilink")).
 2.  The validator may give additional feedback, e.g., an explanation of
-    the judgment to humans (see [Reporting Additional Feedback](#Reporting_Additional_Feedback "wikilink")).
+    the judgment to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
 ## Invocation
 

--- a/spec/problem_package_format.md
+++ b/spec/problem_package_format.md
@@ -344,7 +344,7 @@ At the top level, the test data is divided into exactly two groups:
 
 The <em>result</em> of a test data group is computed by applying a
 <em>grader</em> to all of the sub-results (test cases and subgroups) in
-the group. See [Graders](#Graders "wikilink") for more details.
+the group. See [Graders](#graders "wikilink") for more details.
 
 </s>
 
@@ -474,7 +474,7 @@ arguments.
 Output Validators are used if the problem requires more complicated
 output validation than what is provided by the default diff variant
 described below. They are provided in `output_validators/`, and must
-adhere to the [Output validator](Output_validator "wikilink")
+adhere to the [Output validator](output_validators "wikilink")
 specification.
 
 All output validators provided will be run on the output for every test
@@ -581,7 +581,7 @@ modes for aggregating the score -- *sum*, *avg*, *min*, *max* -- and two
 flags -- *ignore\_sample* and *accept\_if\_any\_accepted*. These modes
 can be set by providing their names as command line arguments (through
 the "grader\_flags" option in
-[testdata.yaml](#Test_Data_Groups "wikilink")). If multiple conflicting
+[testdata.yaml](#test-data-groups "wikilink")). If multiple conflicting
 modes are given, the last one is used. Their meaning are as follows.
 
 </div>
@@ -643,9 +643,7 @@ them once.
 
 ## See also
 
-  - [Output validator](Output_validator "wikilink")
-  - [Sample problem.yaml](Sample_problem.yaml "wikilink")
-  - [Problem format directory
-    structure](Problem_format_directory_structure "wikilink")
-  - [Problem Format
-    Verification](Problem_Format_Verification "wikilink")
+  - [Output validator](output_validators "wikilink")
+  - [Sample problem.yaml](/examples/problem_yaml "wikilink")
+  - [Problem format directory structure](problem_format_directory_structure "wikilink") (TBD)
+  - [Problem Format Verification](problem_format_verification "wikilink") (TBD)

--- a/spec/problem_package_format.md
+++ b/spec/problem_package_format.md
@@ -557,7 +557,7 @@ score. <s>Format to be extended.</s>
 <div class="kattis">
 
 
-The score is taken from the `score.txt` files produced by the ouput
+The score is taken from the `score.txt` files produced by the output
 validator. If no `score.txt` exists the score will be as defined by the
 grading accept\_score and reject\_score setting from problem.yaml.
 


### PR DESCRIPTION
- fix internal links; apparently "-" instead of "_" is used to connect
  words in anchors in github markdown
- rename two files to be more consistent with their URL path
- add "TBD" for links to two files that don't exist yet

I don't have an environment where I could test this. This is based on some feedback from Jeff Donahoo.