### PR TITLE
Fix for CI

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: Problem Package Format
+repository: Kattis/problem-package-format
 lang: en
 description: Problem Package Format Specification
 


### PR DESCRIPTION
Fixes a missing value to make gitlab CI work. Click the `Site preview` link on  the `show all checks` to show the preview.