### PR TITLE
Change default Python version to Python 3

### DIFF
--- a/spec/problem_package_format.md
+++ b/spec/problem_package_format.md
@@ -91,8 +91,8 @@ entry point in the table below will be used.
 | pascal     | Pascal      |                     | .pas                      |                                                                                              |
 | php        | PHP         | main.php            | .php                      |                                                                                              |
 | prolog     | Prolog      |                     | .pl                       |                                                                                              |
-| python2    | Python 2    | main.py             | .py                       | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
-| python3    | Python 3    | main.py             | .py                       | Matches the regex "`^#!.*python3`"                                                           |
+| python2    | Python 2    | main.py             | .py                       | Matches the regex "`^#!.*python2`" |
+| python3    | Python 3    | main.py             | .py                       | Matches the regex "`^#!.*python3`", and default if shebang does not match any other language                                                           |
 | ruby       | Ruby        |                     | .rb                       |                                                                                              |
 | rust       | Rust        |                     | .rs                       |                                                                                              |
 | scala      | Scala       |                     | .scala                    |                                                                                              |


### PR DESCRIPTION
As discussed in https://github.com/Kattis/problem-package-format/issues/15.

This PR does not include any wording on versioning of the spec or compatibility; that will come as part of https://github.com/Kattis/problem-package-format/issues/18 instead.