### PR TITLE
Add rejected submission subdirectory

### DIFF
--- a/spec/problem_package_format.md
+++ b/spec/problem_package_format.md
@@ -384,6 +384,10 @@ subdirectories of `submissions/`. The possible subdirectories are:
 | wrong\_answer         | Wrong answer for some test file, but is not too slow and does not crash for any test file                                          |                                          |
 | time\_limit\_exceeded | Too slow for some test file. May also give wrong answer but not crash for any test file.                                           |                                          |
 | run\_time\_error      | Crashes for some test file                                                                                                         |                                          |
+| rejected              | Receives a rejected verdict (wrong answer, time limit exceeded or run-time error) on some test file.                               |                                          |
+
+The `rejected` subdirectory is primarily intended for submissions that may be rejected for multiple reasons.
+Prefer using one of the other subdirectories for solutions with a single, clear reason for rejection.
 
 
 <div class="kattis">


### PR DESCRIPTION
As discussed in https://github.com/Kattis/problem-package-format/issues/17.

I added some normative guidance on the folder for users (since I think this spec is not use primarily by implementers, but by problem creators).