### PR TITLE
Clarify that sample files for interactive problems MUST NOT be displayed to teams

### DIFF
--- a/spec/2023-07-draft/problem_package_format.md
+++ b/spec/2023-07-draft/problem_package_format.md
@@ -272,9 +272,10 @@ A sample test case may have just an `.interaction` file without a
 corresponding `.in` and `.ans` file. However, if either of a `.in` or a
 `.ans` file is present the other one must also be present. Unlike `.in` and
 `.ans` files for non-interactive problem, interactive `.in` and `.ans` files
-are not meant to be displayed in the problem statement. If you want to
-provide files related to interactive problems (such as testing tools or input
-files) you can use [attachments](#attachments).
+must not be displayed to teams: not in the problem statement, nor as
+part of sample input download. If you want to provide files related to
+interactive problems (such as testing tools or input files) you can use
+[attachments](#attachments).
 
 ### Test Data Groups
 


### PR DESCRIPTION
Fix #41 

(NOTE: Domjudge currently includes .in and .ans files for interactive problems in the sample zip download, which should not be the case. @eldering )