### PR TITLE
Make versions consistent

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -35,13 +35,13 @@ All floating point numbers must be given as the external character sequences def
 ### Programs
 
 There are a number of different kinds of programs that may be provided in the problem package: submissions, input validators, and output validators.
-All programs are always represented by a single file or directory.
-In other words, if a program consists of several files, these must be provided in a single directory.
+All programs are always represented by a single file or directory. 
+In other words, if a program consists of several files, these must be provided in a single directory. 
 The name of the program, for the purpose of referring to it within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
 Validators, but not submissions, 
-in the form of a directory may include two POSIX-compliant scripts "build" and "run".
+in the form of a directory may include two POSIX-compliant scripts "build" and "run". 
 If at least one of these two files is included:
 
 1. First, if the `build` script is present, it will be run. 
@@ -52,7 +52,7 @@ If at least one of these two files is included:
 
 Programs without `build` and `run` scripts are built and run according to what language is used. 
 Language is determined by looking at the file endings. 
-If a single language from the table below can't be determined, building fails.
+If a single language from the table below can't be determined, building fails. 
 
 For languages where there could be several entry points, the default entry point in the table below will be used.
 
@@ -247,13 +247,13 @@ A sample test case may have just an `.interaction` file without a corresponding 
 However, if either of a `.in` or a `.ans` file is present the other one must also be present. 
 Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams: 
 not in the problem statement, nor as part of sample input download. 
-If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments).
+If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments). 
 
 ### Test Data Groups
 
 <div class="not-icpc">
 
-The test data for the problem can be organized into a tree-like structure.
+The test data for the problem can be organized into a tree-like structure. 
 Each node of this tree is represented by a directory and referred to as a test data group. 
 Each test data group may consist of zero or more test cases (i.e., input-answer files) and zero or more subgroups of test data (i.e., subdirectories).
 
@@ -265,20 +265,20 @@ At the top level, the test data is divided into exactly two groups: `sample` and
 <div class="not-icpc">
 
 The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group. 
-See [Graders](#graders) for more details.
+See [Graders](#graders "wikilink") for more details. 
 
 </div>
 
-Test files and groups will be used in lexicographical order on file base name.
-If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
+Test files and groups will be used in lexicographical order on file base name. 
+If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used. 
 
 <div class="not-icpc">
 
 In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed. 
 If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used. 
-If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values.
+If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values. 
 
-The format of `testdata.yaml` is as follows:
+The format of `testdata.yaml` is as follows: 
 
 | Key                    | Type                                | Default                 | Comments                                                                                                                                                                                                                                                                                                                                                                              |
 | ---------------------- | ----------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -299,13 +299,13 @@ The rejected input files can be organized into a tree-like structure similar to 
 
 ## Included Code
 
-Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`.
+Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`. 
 
 The files should be copied from a language directory based on the language of the submission, 
 to the submission files before compiling, overwriting files from the submission in the case of name collision. 
 Language must be given as one of the language codes in the language table in the overview section. 
 If any of the included files are supposed to be the main file (i.e. a driver), 
-that file must have the language dependent name as given in the table referred above.
+that file must have the language dependent name as given in the table referred above. 
 
 </div>
 
@@ -322,47 +322,47 @@ The possible subdirectories are:
 | time_limit_exceeded                               | Too slow for some test file. May also give wrong answer but not crash for any test file.                      |
 | run_time_error                                    | Crashes for some test file                                                                                    |
 
-Every file or directory in these directories represents a separate solution.
+Every file or directory in these directories represents a separate solution. 
 Same requirements as for submissions with regards to filenames. 
-It is mandatory to provide at least one accepted solution.
+It is mandatory to provide at least one accepted solution. 
 
-Submissions must read input data from standard input, and write output to standard output.
+Submissions must read input data from standard input, and write output to standard output. 
 
 ## Input Validators
 
 Input Validators, for verifying the correctness of the input files, are provided in `input_validators/`. 
-Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
+Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program. 
 
 All input validators provided will be run on every input file. 
-Validation fails if any validator fails.
+Validation fails if any validator fails. 
 
 ### Invocation
 
-An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
+An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
 
 All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of. 
-Validation fails if any validator fails.
+Validation fails if any validator fails. 
 
-When invoked the input validator will get the input file on stdin.
+When invoked the input validator will get the input file on stdin. 
 
-The validator should be possible to use as follows on the command line:
+The validator should be possible to use as follows on the command line: 
 
 `./validator [arguments] < inputfile`
 
 ### Output
 
 The input validator may output debug information on stdout and stderr. 
-This information may be displayed to the user upon invocation of the validator.
+This information may be displayed to the user upon invocation of the validator. 
 
 ### Exit codes
 
 The input validator must exit with code 42 on successful validation. 
-Any other exit code means that the input file could not be confirmed as valid.
+Any other exit code means that the input file could not be confirmed as valid. 
 
 #### Dependencies
 
 The validator MUST NOT read any files outside those defined in the Invocation section. 
-Its result MUST depend only on these files and the arguments.
+Its result MUST depend only on these files and the arguments. 
 
 ## Output Validator
 
@@ -387,7 +387,7 @@ It must adhere to the Output validator specification described below.
 
 <span class="not-icpc">The output validator provided will be run on the output for every test data file using the arguments specified for the test data group.</span>
 
-#### Default Output Validator Specification
+### Default Output Validator Specification
 
 The default output validator is essentially a beefed-up diff. 
 In its default mode, it tokenizes the files to compare and compares them token by token. 
@@ -517,12 +517,12 @@ Almost all test cases failed, are you even trying to solve the problem?
 #### Validator standard output and standard error
 
 A validator program is allowed to write any kind of debug information to its standard error pipe. 
-This information may be displayed to the user upon invocation of the validator.
+This information may be displayed to the user upon invocation of the validator. 
 
 ## Grading
 
 For pass-fail problems, the verdict of a submission is the first non-accepted verdict, 
-where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order).
+where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order). 
 
 <div class="not-icpc">
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -11,31 +11,26 @@ This is the `2023-07-draft` version of the specification.
 
 ## Overview
 
-This document describes the format of a _Kattis problem package_, used for
-distributing and sharing problems for algorithmic programming contests as
-well as educational use.
+This document describes the format of a _Kattis problem package_, 
+used for distributing and sharing problems for algorithmic programming contests as well as educational use.
 
 ### General Requirements
 
-The package consists of a single directory containing files as described
-below. The name of the directory must consist solely of lower case letters
-a-z and digits 0-9. Alternatively it can be a ZIP compressed archive of such
-a directory with identical base name and extension `.kpp` or `.zip`.
+The package consists of a single directory containing files as described below. 
+The name of the directory must consist solely of lower case letters a-z and digits 0-9. 
+Alternatively it can be a ZIP compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
 
-All file names for files included in the package must match the following
-regexp
+All file names for files included in the package must match the following regexp:
 
 `[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]`
 
-I.e., it must be of length at least 2, consist solely of lower or upper case
-letters a-z, A-Z, digits 0-9, period, dash or underscore, but must not begin
-or end with period, dash or underscore.
+I.e., it must be of length at least 2, 
+consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore, 
+but must not begin or end with period, dash or underscore.
 
-All text files for a problem must be UTF-8 encoded and not have a byte order
-mark.
+All text files for a problem must be UTF-8 encoded and not have a byte order mark.
 
-All floating point numbers must be given as the external character sequences
-defined by IEEE 754-2008 and may use up to double precision.
+All floating point numbers must be given as the external character sequences defined by IEEE 754-2008 and may use up to double precision.
 
 ### Programs
 
@@ -45,21 +40,21 @@ In other words, if a program consists of several files, these must be provided i
 The name of the program, for the purpose of referring to it within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
-Validators, but not submissions, in the form of a directory may include two POSIX-compliant scripts "build" and "run".
+Validators, but not submissions, 
+in the form of a directory may include two POSIX-compliant scripts "build" and "run".
 If at least one of these two files is included:
 
-1. First, if the `build` script is present, it will be run. The
-   working directory will be (a copy of) the program directory. The
-   `run` file must exist after `build` is done.
-2. Then, the `run` file (which now exists) must be executable, and
-   will be invoked in the same way as a single file program.
+1. First, if the `build` script is present, it will be run. 
+   The working directory will be (a copy of) the program directory. 
+   The `run` file must exist after `build` is done.
+2. Then, the `run` file (which now exists) must be executable, 
+   and will be invoked in the same way as a single file program.
 
-Programs without `build` and `run` scripts are built and run according to what
-language is used. Language is determined by looking at the file endings. If a
-single language from the table below can't be determined, building fails.
+Programs without `build` and `run` scripts are built and run according to what language is used. 
+Language is determined by looking at the file endings. 
+If a single language from the table below can't be determined, building fails.
 
-For languages where there could be several entry points, the default entry
-point in the table below will be used.
+For languages where there could be several entry points, the default entry point in the table below will be used.
 
 | Code       | Language    | Default entry point | File endings              |
 | ---------- | ----------- | ------------------- | ------------------------- |
@@ -83,30 +78,26 @@ point in the table below will be used.
 | rust       | Rust        |                     | .rs                       |
 | scala      | Scala       |                     | .scala                    |
 
-New in version `2023-07`: `.py` files now default to Python 3, and using shebangs are no longer supported; Python 2 has to be explicitly indicated by the `.py2` extension.
+New in version `2023-07`: `.py` files now default to Python 3, and using shebangs are no longer supported; 
+Python 2 has to be explicitly indicated by the `.py2` extension.
 
 <div class="not-icpc">
 
 ### Problem Types
 
-There are two types of problems: <em>pass-fail</em> problems and
-<em>scoring</em> problems. In pass-fail problems, submissions are basically
-judged as either accepted or rejected (though the "rejected" judgement is
-more fine-grained and divided into results such as "Wrong Answer", "Time
-Limit Exceeded", etc). In scoring problems, a submission that is accepted is
-additionally given a score, which is a numeric value(and the goal is to
-maximize this value).
+There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems. 
+In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc). 
+In scoring problems, a submission that is accepted is additionally given a score, which is a numeric value (and the goal is to maximize this value).
 
 </div>
 
 ## Problem Metadata
 
-Metadata about the problem (e.g., source, license, limits) are provided in a
-UTF-8 encoded YAML file named `problem.yaml` placed in the root directory of
-the package.
+Metadata about the problem (e.g., source, license, limits) are provided in a UTF-8 encoded YAML file named `problem.yaml` placed in the root directory of the package.
 
-The keys are defined as below. Keys are optional unless explicitly stated. Any
-unknown keys should be treated as an error.
+The keys are defined as below. 
+Keys are optional unless explicitly stated. 
+Any unknown keys should be treated as an error. 
 
 | Key                                     | Type                                                        | Default                                                 | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | --------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -128,8 +119,7 @@ unknown keys should be treated as an error.
 
 Allowed values for license.
 
-Values other than _unknown_ or _public domain_ requires rights_owner to have
-a value.
+Values other than _unknown_ or _public domain_ requires rights_owner to have a value.
 
 | Value         | Comments                                                                     | Link                                             |
 | ------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ |
@@ -159,10 +149,9 @@ A map with the following keys:
 | validation_memory  | optional, in MiB           | system default | 2048                   |
 | validation_output  | optional, in MiB           | system default | 8                      |
 
-For most keys the system default will be used if nothing is specified. This
-can vary, but you SHOULD assume that it's reasonable. Only specify limits
-when the problem needs a specific limit, but do specify limits even if
-the "typical system default" is what is needed.
+For most keys the system default will be used if nothing is specified. 
+This can vary, but you SHOULD assume that it's reasonable. 
+Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
 
 #### Problem Timing
 
@@ -173,32 +162,24 @@ the "typical system default" is what is needed.
 | ac_to_time_limit  | float    | 2.0     |
 | time_limit_to_tle | float    | 1.5     |
 
-The value of `time_limit` is an integer or floating-point problem time limit,
-in seconds. The time multipliers specify safety margins relative to the
-slowest accepted submission `T_ac` and fastest time_limit_exceeded
-submission `T_tle`. The `time_limit` must satisfy `T_ac * ac_to_time_limit <=
-time_limit` and `time_limit * time_limit_to_tle <= T_tle`. In these
-calculations, `T_tle` is treated as infinity if the problem does not provide
-at least one time_limit_exceeded submission.
+The value of `time_limit` is an integer or floating-point problem time limit, in seconds. 
+The time multipliers specify safety margins relative to the slowest accepted submission `T_ac` and fastest time_limit_exceeded submission `T_tle`. 
+The `time_limit` must satisfy `T_ac * ac_to_time_limit <= time_limit` and `time_limit * time_limit_to_tle <= T_tle`. 
+In these calculations, `T_tle` is treated as infinity if the problem does not provide at least one time_limit_exceeded submission.
 
-If no `time_limit` is provided, the default value is the smallest integer
-multiple of `time_resolution` that satisfies the above inequalities. It is an
-error if no such multiple exists. The `time_resolution` key is ignored if the
-problem provides an explicit time limit (and in particular, the time limit is
-not required to be a multiple of the resolution). Since time multipliers are
-more future-proof than absolute time limits, avoid specifying `time_limit`
-whenever practical.
+If no `time_limit` is provided, the default value is the smallest integer multiple of `time_resolution` that satisfies the above inequalities. 
+It is an error if no such multiple exists. 
+The `time_resolution` key is ignored if the problem provides an explicit time limit (and in particular, the time limit is not required to be a multiple of the resolution). 
+Since time multipliers are more future-proof than absolute time limits, avoid specifying `time_limit` whenever practical.
 
 Contest systems should make a best effort to respect the problem time limit,
-and should warn when importing a problem whose time limit is specified with
-precision greater than can be resolved by system timers.
+and should warn when importing a problem whose time limit is specified with precision greater than can be resolved by system timers.
 
 <div class="not-icpc">
 
 ### languages
 
-A space separated list of language code from the table in the overview section
-or _all_.
+A space separated list of language code from the table in the overview section or _all_.
 
 If a list is given, the problem may only be solved using those languages.
 
@@ -206,124 +187,96 @@ If a list is given, the problem may only be solved using those languages.
 
 ## Problem Statements
 
-The problem statement of the problem is provided in the directory
-`problem_statement/`.
+The problem statement of the problem is provided in the directory `problem_statement/`.
 
-This directory must contain one file per language, for at least one language,
-named `problem.`\<language\>`.`\<filetype\>, that contains the problem text
-itself, including input and output specifications, but not sample input and
-output. Language must be given as the shortest ISO 639 code. If needed a
-hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code.
-Optionally, the language code can be left out, the default is then English
-(`en`). Filetype can be either `tex` for LaTeX files, `md` for Markdown, or
-`pdf` for PDF.
+This directory must contain one file per language, for at least one language, named `problem.`\<language\>`.`\<filetype\>, 
+that contains the problem text itself, including input and output specifications, but not sample input and output. 
+Language must be given as the shortest ISO 639 code. 
+If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code. 
+Optionally, the language code can be left out, the default is then English (`en`). 
+Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PDF.
 
-Please note that many kinds of transformations on the problem statements, such
-as conversion to HTML or styling to fit in a single document containing many
-problems will not be possible for PDF problem statements, so using this
-format should be avoided if at all possible.
+Please note that many kinds of transformations on the problem statements, 
+such as conversion to HTML or styling to fit in a single document containing many problems will not be possible for PDF problem statements, 
+so using this format should be avoided if at all possible.
 
-Auxiliary files needed by the problem statement files must all be in
-`<short_name>/problem_statement/`. `problem.<language>.<filetype>` should
-reference auxiliary files as if the working directory is
-`<short_name>/problem_statement/`. Image file formats supported are `.png`,
-`.jpg`, `.jpeg`, and `.pdf`.
+Auxiliary files needed by the problem statement files must all be in `<short_name>/problem_statement/`. 
+`problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`. 
+Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-A LaTeX file may include the Problem name using the LaTeX command
-`\problemname` in case LaTeX formatting of the title is wanted. <span
-class="not-icpc">If it's not included the problem name specified in
-`problem.yaml` will be used.</span>
+A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted. 
+<span class="not-icpc">If it's not included the problem name specified in `problem.yaml` will be used.</span>
 
-The problem statements must only contain the actual problem statement, no
-sample data.
+The problem statements must only contain the actual problem statement, no sample data.
 
 ## Attachments
 
-Public, i.e. non-secret, files to be made available in addition to the problem
-statement and sample test data are provided in the directory `attachments/`.
+Public, i.e. non-secret, files to be made available in addition to the problem statement and sample test data are provided in the directory `attachments/`.
 
 ## Test data
 
-The test data are provided in subdirectories of `data/`. The sample data in
-`data/sample/` and the secret data in `data/secret/`.
+The test data are provided in subdirectories of `data/`. 
+The sample data in `data/sample/` and the secret data in `data/secret/`.
 
-All input and answer files have the filename extension `.in` and `.ans`
-respectively.
+All input and answer files have the filename extension `.in` and `.ans` respectively.
 
 ### Annotations
 
 Optionally a hint, a description and an illustration file may be provided.
 
-The hint file is a text file with filename extension`.hint` giving a hint for
-solving an input file. The hint file is meant to be given as feedback, i.e.
-to somebody that fails to solve the problem.
+The hint file is a text file with filename extension`.hint` giving a hint for solving an input file. 
+The hint file is meant to be given as feedback, i.e. to somebody that fails to solve the problem.
 
-The description file is a text file with filename extension `.desc` describing
-the purpose of an input file. The description file is meant to be privileged
-information that explains the purpose of the related test file, e.g. what
-cases it's supposed to test.
+The description file is a text file with filename extension `.desc` describing the purpose of an input file. 
+The description file is meant to be privileged information that explains the purpose of the related test file, e.g. what cases it's supposed to test.
 
-The Illustration is an image file with filename extension `.png`, `.jpg`,
-`.jpeg`, or `.svg`. The illustration is meant to be privileged information
-illustrating the related test file.
+The Illustration is an image file with filename extension `.png`, `.jpg`, `.jpeg`, or `.svg`. 
+The illustration is meant to be privileged information illustrating the related test file.
 
-Input, answer, description, hint and image files are matched by the base
-name.
+Input, answer, description, hint and image files are matched by the base name.
 
 ### Interactive Problems
 
-For interactive problems, any sample test cases must provide an interaction
-protocol with the extension `.interaction` for each sample demonstrating the
-communication between the submission and the output validator, meant to be
-displayed in the problem statement. An interaction protocol consists of a
-series of lines starting with `>` and `<`. Lines starting with `>` signify an
-output from the submission to the output validator, while `<` signify an
-input from the output validator to the submission.
+For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator, 
+meant to be displayed in the problem statement. 
+An interaction protocol consists of a series of lines starting with `>` and `<`. 
+Lines starting with `>` signify an output from the submission to the output validator, 
+while `<` signify an input from the output validator to the submission.
 
-A sample test case may have just an `.interaction` file without a
-corresponding `.in` and `.ans` file. However, if either of a `.in` or a
-`.ans` file is present the other one must also be present. Unlike `.in` and
-`.ans` files for non-interactive problem, interactive `.in` and `.ans` files
-must not be displayed to teams: not in the problem statement, nor as
-part of sample input download. If you want to provide files related to
-interactive problems (such as testing tools or input files) you can use
-[attachments](#attachments).
+A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file. 
+However, if either of a `.in` or a `.ans` file is present the other one must also be present. 
+Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams: 
+not in the problem statement, nor as part of sample input download. 
+If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments).
 
 ### Test Data Groups
 
 <div class="not-icpc">
 
 The test data for the problem can be organized into a tree-like structure.
-Each node of this tree is represented by a directory and referred to as a
-test data group. Each test data group may consist of zero or more test cases
-(i.e., input-answer files) and zero or more subgroups of test data
-(i.e., subdirectories).
+Each node of this tree is represented by a directory and referred to as a test data group. 
+Each test data group may consist of zero or more test cases (i.e., input-answer files) and zero or more subgroups of test data (i.e., subdirectories).
 
 </div>
 
-At the top level, the test data is divided into exactly two groups: `sample`
-and `secret`. <span class="not-icpc">These two groups may be further split into
-subgroups as desired. </span>
+At the top level, the test data is divided into exactly two groups: `sample` and `secret`. 
+<span class="not-icpc">These two groups may be further split into subgroups as desired.</span>
 
 <div class="not-icpc">
 
-The <em>result</em> of a test data group is computed by applying a
-<em>grader</em> to all of the sub-results (test cases and subgroups) in the
-group. See [Graders](#graders) for more details.
+The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group. 
+See [Graders](#graders) for more details.
 
 </div>
 
 Test files and groups will be used in lexicographical order on file base name.
-If a specific order is desired a numbered prefix such as `00`, `01`, `02`,
-`03`, and so on, can be used.
+If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
 
 <div class="not-icpc">
 
-In each test data group, a file `testdata.yaml` may be placed to specify how
-the result of the test data group should be computed. If a test data group
-has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor
-group that has one will be used. If there is no `testdata.yaml` file in the
-root `data` group, one is implicitly added with the default values.
+In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed. 
+If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used. 
+If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values.
 
 The format of `testdata.yaml` is as follows:
 
@@ -337,35 +290,29 @@ The format of `testdata.yaml` is as follows:
 
 ### Invalid Input Files
 
-In the `data/` directory, there may be an `invalid_inputs/` directory
-containing input files that must be rejected by at least one input validator.
-These are meant to only test the input validators, and are not used for
-judging. The rejected input files can be organized into a tree-like structure
-similar to the test data. <span class="not-icpc"> There may be `testdata.yaml`
-files within this structure, but they may only contain the key
-`input_validator_flags`. </span>
+In the `data/` directory, there may be an `invalid_inputs/` directory containing input files that must be rejected by at least one input validator.
+These are meant to only test the input validators, and are not used for judging. 
+The rejected input files can be organized into a tree-like structure similar to the test data. 
+<span class="not-icpc"> There may be `testdata.yaml` files within this structure, but they may only contain the key `input_validator_flags`.</span>
 
 <div class="not-icpc">
 
 ## Included Code
 
-Code that should be included with all submissions are provided in one
-directory per supported language, called `include/<language>/`.
+Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`.
 
-The files should be copied from a language directory based on the language of
-the submission, to the submission files before compiling, overwriting files
-from the submission in the case of name collision. Language must be given as
-one of the language codes in the language table in the overview section. If
-any of the included files are supposed to be the main file (i.e. a driver),
-that file must have the language dependent name as given in the table
-referred above.
+The files should be copied from a language directory based on the language of the submission, 
+to the submission files before compiling, overwriting files from the submission in the case of name collision. 
+Language must be given as one of the language codes in the language table in the overview section. 
+If any of the included files are supposed to be the main file (i.e. a driver), 
+that file must have the language dependent name as given in the table referred above.
 
 </div>
 
 ## Example Submissions
 
-Correct and incorrect solutions to the problem are provided in subdirectories
-of `submissions/`. The possible subdirectories are:
+Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`. 
+The possible subdirectories are:
 
 | Value                                             | Requirement                                                                                                   | Comment                                                                 |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -376,30 +323,25 @@ of `submissions/`. The possible subdirectories are:
 | run_time_error                                    | Crashes for some test file                                                                                    |
 
 Every file or directory in these directories represents a separate solution.
-Same requirements as for submissions with regards to filenames. It is
-mandatory to provide at least one accepted solution.
+Same requirements as for submissions with regards to filenames. 
+It is mandatory to provide at least one accepted solution.
 
-Submissions must read input data from standard input, and write output to
-standard output.
+Submissions must read input data from standard input, and write output to standard output.
 
 ## Input Validators
 
-Input Validators, for verifying the correctness of the input files, are
-provided in `input_validators/`. Input validators can be specified as
-VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending
-`.ctd`), or as a program.
+Input Validators, for verifying the correctness of the input files, are provided in `input_validators/`. 
+Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
 
-All input validators provided will be run on every input file. Validation
-fails if any validator fails.
+All input validators provided will be run on every input file. 
+Validation fails if any validator fails.
 
 ### Invocation
 
-An input validator program must be an application (executable or interpreted)
-capable of being invoked with a command line call.
+An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
 
-All input validators provided will be run on every test data file using the
-arguments specified for the test data group they are part of. Validation
-fails if any validator fails.
+All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of. 
+Validation fails if any validator fails.
 
 When invoked the input validator will get the input file on stdin.
 
@@ -409,53 +351,47 @@ The validator should be possible to use as follows on the command line:
 
 ### Output
 
-The input validator may output debug information on stdout and stderr. This
-information may be displayed to the user upon invocation of the validator.
+The input validator may output debug information on stdout and stderr. 
+This information may be displayed to the user upon invocation of the validator.
 
 ### Exit codes
 
-The input validator must exit with code 42 on successful validation. Any other
-exit code means that the input file could not be confirmed as valid.
+The input validator must exit with code 42 on successful validation. 
+Any other exit code means that the input file could not be confirmed as valid.
 
 #### Dependencies
 
-The validator MUST NOT read any files outside those defined in the Invocation
-section. Its result MUST depend only on these files and the arguments.
+The validator MUST NOT read any files outside those defined in the Invocation section. 
+Its result MUST depend only on these files and the arguments.
 
 ## Output Validator
 
 ### Overview
 
-An output validator is a program that is given the output of a submitted
-program, together with the corresponding input file, and a correct
-answer file for the input, and then decides whether the output provided
-is a correct output for the given input file.
+An output validator is a program that is given the output of a submitted program, 
+together with the corresponding input file, 
+and a correct answer file for the input, 
+and then decides whether the output provided is a correct output for the given input file.
 
-A validator program must be an application (executable or interpreted)
-capable of being invoked with a command line call. The details of this
-invocation are described below. The validator program has two ways of
-reporting back the results of validating:
+A validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
+The details of this invocation are described below. 
+The validator program has two ways of reporting back the results of validating:
 
 1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
-2.  The validator may give additional feedback, e.g., an explanation of
-    the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
+2.  The validator may give additional feedback, 
+    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
-A custom output validator is used if the problem requires more complicated output
-validation than what is provided by the default diff variant described below.
+A custom output validator is used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
 It must be provided as the directory `output_validator/`, and may contain `build` and `run` scripts.
 It must adhere to the Output validator specification described below.
 
-<span class="not-icpc">
-The output validator provided will be run on the output for every test data
-file using the arguments specified for the test data group.
-</span>
+<span class="not-icpc">The output validator provided will be run on the output for every test data file using the arguments specified for the test data group.</span>
 
 #### Default Output Validator Specification
 
-The default output validator is essentially a beefed-up diff. In its default
-mode, it tokenizes the files to compare and compares them token by token. It
-supports the following command-line arguments to control how tokens are
-compared.
+The default output validator is essentially a beefed-up diff. 
+In its default mode, it tokenizes the files to compare and compares them token by token. 
+It supports the following command-line arguments to control how tokens are compared.
 
 | Arguments                    | Description                                                                                                                                                 |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -465,18 +401,14 @@ compared.
 | `float_absolute_tolerance ε` | indicates that floating-point tokens should be accepted if they are within absolute error ≤ ε (see below for details).                                      |
 | `float_tolerance ε`          | short-hand for applying ε as both relative and absolute tolerance.                                                                                          |
 
-When supplying both a relative and an absolute tolerance, the semantics are
-that a token is accepted if it is within either of the two tolerances. When a
-floating-point tolerance has been set, any valid formatting of floating point
-numbers is accepted for floating point tokens. So for instance if a token in
-the answer file says `0.0314`, a token of `3.14000000e-2` in the output file
-would be accepted. If no floating point tolerance has been set, floating
-point tokens are treated just like any other token and has to match exactly.
+When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the two tolerances. 
+When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating point tokens. 
+So for instance if a token in the answer file says `0.0314`, a token of `3.14000000e-2` in the output file would be accepted. 
+If no floating point tolerance has been set, floating point tokens are treated just like any other token and has to match exactly.
 
 ### Invocation
 
-When invoked the output validator will be passed at least three command
-line parameters and the output stream to validate on stdin.
+When invoked the output validator will be passed at least three command line parameters and the output stream to validate on stdin.
 
 The validator should be possible to use as follows on the command line:
 
@@ -486,103 +418,76 @@ The validator should be possible to use as follows on the command line:
 
 The meaning of the parameters listed above are:
 
-- input: a string specifying the name of the input data file which was
-  used to test the program whose results are being validated.
+- input: 
+  a string specifying the name of the input data file which was used to test the program whose results are being validated.
 
-- judge_answer: a string specifying the name of an arbitrary "answer
-  file" which acts as input to the validator program. The answer file
-  may, but is not necessarily required to, contain the "correct
-  answer" for the problem. For example, it might contain the output
-  which was produced by a judge's solution for the problem when run
-  with input file as input. Alternatively, the "answer file" might
-  contain information, in arbitrary format, which instructs the
-  validator in some way about how to accomplish its task. The meaning
-  of the contents of the answer file is not defined by this standard.
+- judge_answer: 
+  a string specifying the name of an arbitrary "answer file" which acts as input to the validator program. 
+  The answer file may, but is not necessarily required to, contain the "correct answer" for the problem. 
+  For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input. 
+  Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task. 
+  The meaning of the contents of the answer file is not defined by this standard.
 
-- feedback_dir: a string which specifies the name of a "feedback
-  directory" in which the validator can produce "feedback files" in
-  order to report additional information on the validation of the
-  output file. The feedbackdir must end with a path separator
-  (typically '/' or '\\' depending on operating system), so that
-  simply appending a filename to feedbackdir gives the path to a file
-  in the feedback directory.
+- feedback_dir: 
+  a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file. 
+  The feedbackdir must end with a path separator (typically '/' or '\\' depending on operating system), 
+  so that simply appending a filename to feedbackdir gives the path to a file in the feedback directory.
 
-- additional_arguments: in case the problem specifies additional
-  validator_flags, these are passed as additional arguments to the
-  validator on the command line.
+- additional_arguments: 
+  in case the problem specifies additional validator_flags, these are passed as additional arguments to the validator on the command line.
 
-- team_output: the output produced by the program being validated is
-  given on the validator's standard input pipe.
+- team_output: 
+  the output produced by the program being validated is given on the validator's standard input pipe.
 
-- team_input: when running the validator in interactive mode
-  everything written on the validator's standard output pipe is given
-  to the program being validated. Please note that when running
-  interactive the program will only receive the output produced by the
-  validator and will not have direct access to the input file.
+- team_input: 
+  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated. 
+  Please note that when running interactive the program will only receive the output produced by the validator and will not have direct access to the input file.
 
-The two files pointed to by input and judge_answer must exist (though
-they are allowed to be empty) and the validator program must be allowed
-to open them for reading. The directory pointed to by feedback_dir must
-also exist.
+The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading. 
+The directory pointed to by feedback_dir must also exist.
 
 ### Reporting a judgement
 
-A validator program is required to report its judgement by exiting with
-specific exit codes:
+A validator program is required to report its judgement by exiting with specific exit codes:
 
-- If the output is a correct output for the input file (i.e., the
-  submission that produced the output is to be Accepted), the
-  validator exits with exit code 42.
-- If the output is incorrect (i.e., the submission that produced the
-  output is to be judged as Wrong Answer), the validator exits with
-  exit code 43.
+- If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted), 
+  the validator exits with exit code 42.
+- If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer), 
+  the validator exits with exit code 43.
 
-Any other exit code (including 0\!) indicates that the validator did not
-operate properly, and the contest control system invoking the validator
-must take measures to report this to contest personnel. The purpose of
-these somewhat exotic exit codes is to avoid conflict with other exit
-codes that results when the validator crashes. For instance, if the
-validator is written in Java, any unhandled exception results in the
-program crashing with an exit code of 1, making it unsuitable to assign
-a judgement meaning to this exit code.
+Any other exit code (including 0\!) indicates that the validator did not operate properly, 
+and the contest control system invoking the validator must take measures to report this to contest personnel. 
+The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
+For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
+making it unsuitable to assign a judgement meaning to this exit code.
 
 ### Reporting Additional Feedback
 
-The purpose of the feedback directory is to allow the validator program
-to report more information to the contest control system than just the
-accept/reject verdict. Using the feedback directory is optional for a
-validator program, so if one just wants to write a bare-bones minimal
-validator, it can be ignored.
+The purpose of the feedback directory is to allow the validator program to report more information to the contest control system than just the accept/reject verdict. 
+Using the feedback directory is optional for a validator program, so if one just wants to write a bare-bones minimal validator, it can be ignored.
 
-The validator is free to create different files in the feedback
-directory, in order to provide different kinds of information to the
-contest control system, in a simple but organized way. For instance,
-there may be a "judgemessage.txt" file, the contents of which gives a
-message that is presented to a judge reviewing the current submission
-(typically used to help the judge verify why the submission was judged
-as incorrect, by specifying exactly what was wrong with its output).
-Other examples of files that may be useful in some contexts (though not
-in the ICPC) are a score.txt file, giving the submission a score based
-on other factors than correctness, or a teammessage.txt file, giving a
-message to the team that submitted the solution, providing additional
-feedback on the submission.
+The validator is free to create different files in the feedback directory, 
+in order to provide different kinds of information to the contest control system, in a simple but organized way. 
+For instance, there may be a "judgemessage.txt" file, 
+the contents of which gives a message that is presented to a judge reviewing the current submission 
+(typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
+Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file, 
+giving the submission a score based on other factors than correctness, 
+or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A contest control system that implements this standard must support the
-judgemessage.txt file described above (I.e., content of the
-"judgemessage.txt" file, if produced by the validator, must be provided
-by the contest control system to a human judge examining the
-submission). Having the Contest Control System support other files is
-optional.
+A contest control system that implements this standard must support the judgemessage.txt file described above 
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the contest control system to a human judge examining the submission). 
+Having the Contest Control System support other files is optional.
 
-Note that a validator may choose to ignore the feedback directory
-entirely. In particular, the contest control system must not assume that
-the validator program creates any files there at all.
+Note that a validator may choose to ignore the feedback directory entirely. 
+In particular, the contest control system must not assume that the validator program creates any files there at all.
 
 <div class="not-icpc">
 
 #### Multi-pass validation
 
-A multi-pass validator can be used for problems that should run the submission multiple times sequentially, using a new input generated by output validator during the previous invocation of the submission.
+A multi-pass validator can be used for problems that should run the submission multiple times sequentially, 
+using a new input generated by output validator during the previous invocation of the submission.
 
 To signal that the submission should be run again, the output validator must exit with code 42 and output the new input in the file `nextpass.in` in the feedback directory.
 Judging stops if no `nextpass.in` was created, or the output validator exited with any other code.
@@ -611,15 +516,16 @@ Almost all test cases failed, are you even trying to solve the problem?
 
 #### Validator standard output and standard error
 
-A validator program is allowed to write any kind of debug information
-to its standard error pipe. This information may be displayed to the
-user upon invocation of the validator.
+A validator program is allowed to write any kind of debug information to its standard error pipe. 
+This information may be displayed to the user upon invocation of the validator.
 
 ## Grading
 
-For pass-fail problems, the verdict of a submission is the first non-accepted verdict, where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order).
+For pass-fail problems, the verdict of a submission is the first non-accepted verdict, 
+where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order).
 
 <div class="not-icpc">
+
 For scoring problems, the behaviour is configured by the following flags under `grading` in `testdata.yaml`:
 
 | Key         | Type                                    | Description                                                                                                                                                                                                       |

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -460,18 +460,18 @@ A validator program is required to report its judgement by exiting with specific
   the validator exits with exit code 43.
 
 Any other exit code (including 0\!) indicates that the validator did not operate properly, 
-and the contest control system invoking the validator must take measures to report this to contest personnel. 
+and the judging system invoking the validator must take measures to report this to contest personnel. 
 The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
 For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
 making it unsuitable to assign a judgement meaning to this exit code.
 
 ### Reporting Additional Feedback
 
-The purpose of the feedback directory is to allow the validator program to report more information to the contest control system than just the accept/reject verdict. 
+The purpose of the feedback directory is to allow the validator program to report more information to the judging system than just the accept/reject verdict. 
 Using the feedback directory is optional for a validator program, so if one just wants to write a bare-bones minimal validator, it can be ignored.
 
 The validator is free to create different files in the feedback directory, 
-in order to provide different kinds of information to the contest control system, in a simple but organized way. 
+in order to provide different kinds of information to the judging system, in a simple but organized way. 
 For instance, there may be a "judgemessage.txt" file, 
 the contents of which gives a message that is presented to a judge reviewing the current submission 
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
@@ -479,12 +479,12 @@ Other examples of files that may be useful in some contexts (though not in the I
 giving the submission a score based on other factors than correctness, 
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A contest control system that implements this standard must support the judgemessage.txt file described above 
-(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the contest control system to a human judge examining the submission). 
-Having the Contest Control System support other files is optional.
+A judging system that implements this standard must support the judgemessage.txt file described above 
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission). 
+Having the judging system support other files is optional.
 
 Note that a validator may choose to ignore the feedback directory entirely. 
-In particular, the contest control system must not assume that the validator program creates any files there at all.
+In particular, the judging system must not assume that the validator program creates any files there at all.
 
 <div class="not-icpc">
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -7,7 +7,11 @@ sort: 2
 
 # Problem Package Format
 
-This is the `2023-07-draft` version of the specification.
+This is the `2023-07-draft` version of the Kattis problem package format. 
+
+There are two variants of this specification: the Full version, and the ICPC subset. 
+Use the buttons in the sidebar to select one of them. 
+The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>. 
 
 ## Overview
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -430,7 +430,7 @@ The meaning of the parameters listed above are:
   The answer file may, but is not necessarily required to, contain the "correct answer" for the problem. 
   For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input. 
   Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task. 
-  The meaning of the contents of the answer file is not defined by this standard.
+  The meaning of the contents of the answer file is not defined by this format. 
 
 - feedback_dir: 
   a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file. 
@@ -479,7 +479,7 @@ Other examples of files that may be useful in some contexts (though not in the I
 giving the submission a score based on other factors than correctness, 
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A judging system that implements this standard must support the judgemessage.txt file described above 
+A judging system that implements this format must support the judgemessage.txt file described above 
 (I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission). 
 Having the judging system support other files is optional.
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -42,13 +42,15 @@ There can't be two programs of the same kind with the same name.
 
 Validators and graders, but not submissions, 
 in the form of a directory may include two POSIX-compliant scripts "build" and "run". 
-Either both or none of these scripts must be included. 
-If the scripts are present, then:
+If at least one of these two files is included:
 
-- the program will be compiled by executing the build script.
-- the program will be run by executing the run script.
+1. First, if the `build` script is present, it will be run. 
+   The working directory will be (a copy of) the program directory. 
+   The `run` file must exist after `build` is done.
+2. Then, the `run` file (which now exists) must be executable, 
+   and will be invoked in the same way as a single file program.
 
-Programs without build and run scripts are built and run according to what language is used. 
+Programs without `build` and `run` scripts are built and run according to what language is used. 
 Language is determined by looking at the file endings. 
 If a single language from the table below can't be determined, building fails. 
 In the case of Python 2 and 3 which share the same file ending, 
@@ -80,7 +82,7 @@ For languages where there could be several entry points, the default entry point
 
 <div class="not-icpc">
 
-### Problem types
+### Problem Types
 
 There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems. 
 In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc). 
@@ -94,7 +96,7 @@ Metadata about the problem (e.g., source, license, limits) are provided in a UTF
 
 The keys are defined as below. 
 Keys are optional unless explicitly stated. 
-Any unknown keys should be treated as an error.
+Any unknown keys should be treated as an error. 
 
 | Key                                   | Type                                                          | Default                                                 | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -133,8 +135,8 @@ A map with the following keys:
 
 | Key                | Comments             | Default        | Typical system default |
 | ------------------ | -------------------- | -------------- | ---------------------- |
-| time_multiplier    | optional             | 5              |                        |
-| time_safety_margin | optional             | 2              |                        |
+| time_multiplier    | optional float       | 5              |                        |
+| time_safety_margin | optional float       | 2              |                        |
 | memory             | optional, in MiB     | system default | 2048                   |
 | output             | optional, in MiB     | system default | 8                      |
 | code               | optional, in kiB     | system default | 128                    |
@@ -144,7 +146,7 @@ A map with the following keys:
 | validation_memory  | optional, in MiB     | system default | 2048                   |
 | validation_output  | optional, in MiB     | system default | 8                      |
 
-For most keys the system default will be used if nothing is specified.
+For most keys the system default will be used if nothing is specified. 
 This can vary, but you SHOULD assume that it's reasonable. 
 Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
 
@@ -180,7 +182,7 @@ Auxiliary files needed by the problem statement files must all be in `<short_nam
 `problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`. 
 Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
+A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted. 
 
 The problem statements must only contain the actual problem statement, no sample data.
 
@@ -214,14 +216,15 @@ Input, answer, description, hint and image files are matched by the base name.
 
 For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator, 
 meant to be displayed in the problem statement. 
-An interaction protocol consists of a series of lines starting with `>` and `<`.
+An interaction protocol consists of a series of lines starting with `>` and `<`. 
 Lines starting with `>` signify an output from the submission to the output validator, 
 while `<` signify an input from the output validator to the submission.
 
-A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file.
-However, if either of a `.in` or a `.ans` file is present the other one must also be present.
-Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files are not meant to be displayed in the problem statement.
-If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments).
+A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file. 
+However, if either of a `.in` or a `.ans` file is present the other one must also be present. 
+Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams: 
+not in the problem statement, nor as part of sample input download. 
+If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments). 
 
 ### Test Data Groups
 
@@ -239,19 +242,20 @@ At the top level, the test data is divided into exactly two groups: `sample` and
 <div class="not-icpc">
 
 The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group. 
-See [Graders](#graders "wikilink") for more details.
+See [Graders](#graders "wikilink") for more details. 
 
 </div>
 
 Test files and groups will be used in lexicographical order on file base name. 
-If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
+If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used. 
 
 <div class="not-icpc">
 
 In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed. 
-If such a file is not provided for a test data group then the settings for the parent group will be used. 
+If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used. 
+If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values. 
 
-The format of `testdata.yaml` is as follows:
+The format of `testdata.yaml` is as follows: 
 
 | Key                    | Type                                           | Default      | Comments                                                                                                                                                                                                                                                                                                          |
 | ---------------------- | ---------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -268,13 +272,13 @@ The format of `testdata.yaml` is as follows:
 
 ## Included Code
 
-Code that should be included with all submissions are provided in one directory per supported language, called `include/`\<language\>`/`.
+Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`. 
 
 The files should be copied from a language directory based on the language of the submission, 
-to the submission files before compiling, overwriting files from the submission in the case of name collision.
+to the submission files before compiling, overwriting files from the submission in the case of name collision. 
 Language must be given as one of the language codes in the language table in the overview section. 
 If any of the included files are supposed to be the main file (i.e. a driver), 
-that file must have the language dependent name as given in the table referred above.
+that file must have the language dependent name as given in the table referred above. 
 
 </div>
 
@@ -293,45 +297,45 @@ The possible subdirectories are:
 
 Every file or directory in these directories represents a separate solution. 
 Same requirements as for submissions with regards to filenames. 
-It is mandatory to provide at least one accepted solution.
+It is mandatory to provide at least one accepted solution. 
 
-Submissions must read input data from standard input, and write output to standard output.
+Submissions must read input data from standard input, and write output to standard output. 
 
 ## Input Validators
 
-Input Validators, for verifying the correctness of the input files, are provided in `input_validators/` (or the deprecated `input_format_validators/`).
-Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
+Input Validators, for verifying the correctness of the input files, are provided in `input_validators/` (or the deprecated `input_format_validators/`). 
+Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program. 
 
-All input validators provided will be run on every input file.
-Validation fails if any validator fails.
+All input validators provided will be run on every input file. 
+Validation fails if any validator fails. 
 
 ### Invocation
 
-An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
+An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
 
-All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of.
-Validation fails if any validator fails.
+All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of. 
+Validation fails if any validator fails. 
 
-When invoked the input validator will get the input file on stdin.
+When invoked the input validator will get the input file on stdin. 
 
-The validator should be possible to use as follows on the command line:
+The validator should be possible to use as follows on the command line: 
 
 `./validator [arguments] < inputfile`
 
 ### Output
 
-The input validator may output debug information on stdout and stderr.
-This information may be displayed to the user upon invocation of the validator.
+The input validator may output debug information on stdout and stderr. 
+This information may be displayed to the user upon invocation of the validator. 
 
 ### Exit codes
 
 The input validator must exit with code 42 on successful validation. 
-Any other exit code means that the input file could not be confirmed as valid.
+Any other exit code means that the input file could not be confirmed as valid. 
 
 #### Dependencies
 
 The validator MUST NOT read any files outside those defined in the Invocation section. 
-Its result MUST depend only on these files and the arguments.
+Its result MUST depend only on these files and the arguments. 
 
 ## Output Validators
 
@@ -346,9 +350,9 @@ A validator program must be an application (executable or interpreted) capable o
 The details of this invocation are described below. 
 The validator program has two ways of reporting back the results of validating:
 
-1.  The validator must give a judgment (see [Reporting a judgment](#reporting-a-judgment "wikilink")).
+1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
 2.  The validator may give additional feedback, 
-    e.g., an explanation of the judgment to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
+    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
 Custom output Validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below. 
 They are provided in `output_validators/`, and must adhere to the [Output validator](output_validators "wikilink") specification.
@@ -415,9 +419,9 @@ The meaning of the parameters listed above are:
 The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading. 
 The directory pointed to by feedback_dir must also exist.
 
-### Reporting a judgment
+### Reporting a judgement
 
-A validator program is required to report its judgment by exiting with specific exit codes:
+A validator program is required to report its judgement by exiting with specific exit codes:
 
 - If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted), 
   the validator exits with exit code 42.
@@ -428,7 +432,7 @@ Any other exit code (including 0\!) indicates that the validator did not operate
 and the contest control system invoking the validator must take measures to report this to contest personnel. 
 The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
 For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
-making it unsuitable to assign a judgment meaning to this exit code.
+making it unsuitable to assign a judgement meaning to this exit code.
 
 ### Reporting Additional Feedback
 
@@ -438,15 +442,14 @@ Using the feedback directory is optional for a validator program, so if one just
 The validator is free to create different files in the feedback directory, 
 in order to provide different kinds of information to the contest control system, in a simple but organized way. 
 For instance, there may be a "judgemessage.txt" file, 
-the contents of which gives a message that is presented to a judge reviewing the current submission
+the contents of which gives a message that is presented to a judge reviewing the current submission 
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
 Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file, 
 giving the submission a score based on other factors than correctness, 
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
 A contest control system that implements this standard must support the judgemessage.txt file described above 
-(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the contest control system to a human judge examining the
-submission). 
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the contest control system to a human judge examining the submission). 
 Having the Contest Control System support other files is optional.
 
 Note that a validator may choose to ignore the feedback directory entirely. 
@@ -472,20 +475,20 @@ Almost all test cases failed, are you even trying to solve the problem?
 
 #### Validator standard output and standard error
 
-A valididator program is allowed to write any kind of debug information to its standard error pipe. 
-This information may be displayed to the user upon invocation of the validator.
+A validator program is allowed to write any kind of debug information to its standard error pipe. 
+This information may be displayed to the user upon invocation of the validator. 
 
 <div class="not-icpc">
 
 ## Graders
 
 Graders are programs that are given the sub-results of a test data group and aggregate a result for the group. 
-They are provided in `graders/` .
+They are provided in `graders/`. 
 
 For pass-fail problems, this grader will typically just set the verdict to accepted if all sub-results in the group were accepted and otherwise select the "worst" error in the group (see below for definition of "worst"), 
 though it is possible to write a custom grader which e.g. accepts if at least half the sub-results are accepted. 
 For scoring problems, one common grader behaviour would be to always set the verdict to Accepted, 
-with the score being the sum of scores of the items in the test group.
+with the score being the sum of scores of the items in the test group. 
 
 ### Invocation
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -11,61 +11,50 @@ This is the `legacy` version of the specification
 
 ## Overview
 
-This document describes the format of a _Kattis problem package_, used
-for distributing and sharing problems for algorithmic programming
-contests as well as educational use.
+This document describes the format of a _Kattis problem package_, 
+used for distributing and sharing problems for algorithmic programming contests as well as educational use.
 
 ### General Requirements
 
-The package consists of a single directory containing files as described
-below. The name of the directory must consist solely of lower case
-letters a-z and digits 0-9. Alternatively it can be a ZIP compressed
-archive of such a directory with identical base name and extension
-`.kpp` or `.zip`.
+The package consists of a single directory containing files as described below. 
+The name of the directory must consist solely of lower case letters a-z and digits 0-9. 
+Alternatively it can be a ZIP compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
 
-All file names for files included in the package must match the
-following regexp
+All file names for files included in the package must match the following regexp:
 
 `[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]`
 
-I.e., it must be of length at least 2, consist solely of lower or upper
-case letters a-z, A-Z, digits 0-9, period, dash or underscore, but must
-not begin or end with period, dash or underscore.
+I.e., it must be of length at least 2, 
+consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore, 
+but must not begin or end with period, dash or underscore.
 
-All text files for a problem must be UTF-8 encoded and not have a byte
-order mark.
+All text files for a problem must be UTF-8 encoded and not have a byte order mark.
 
-All floating point numbers must be given as the external character
-sequences defined by IEEE 754-2008 and may use up to double precision.
+All floating point numbers must be given as the external character sequences defined by IEEE 754-2008 and may use up to double precision.
 
 ### Programs
 
-There are a number of different kinds of programs that may be provided
-in the problem package; submissions, input validators, output
-validators<span class="not-icpc">, and graders</span>.
-All programs are always represented by a single file or directory. In other
-words, if a program consists of several files, these must be provided in a
-single directory. The name of the program, for the purpose of referring to it
-within the package is the base name of the file or the name of the directory.
+There are a number of different kinds of programs that may be provided in the problem package; submissions, input validators, output validators<span class="not-icpc">, and graders</span>.
+All programs are always represented by a single file or directory. 
+In other words, if a program consists of several files, these must be provided in a single directory. 
+The name of the program, for the purpose of referring to it within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
-Validators and graders, but not submissions, in the form of a directory
-may include two POSIX-compliant scripts "build" and "run". Either both
-or none of these scripts must be included. If the scripts are present,
-then:
+Validators and graders, but not submissions, 
+in the form of a directory may include two POSIX-compliant scripts "build" and "run". 
+Either both or none of these scripts must be included. 
+If the scripts are present, then:
 
 - the program will be compiled by executing the build script.
 - the program will be run by executing the run script.
 
-Programs without build and run scripts are built and run according to
-what language is used. Language is determined by looking at the file
-endings. If a single language from the table below can't be determined,
-building fails. In the case of Python 2 and 3 which share the same file
-ending, language will be determined by looking at the shebang line which
-must match the regular expressions in the table below.
+Programs without build and run scripts are built and run according to what language is used. 
+Language is determined by looking at the file endings. 
+If a single language from the table below can't be determined, building fails. 
+In the case of Python 2 and 3 which share the same file ending, 
+language will be determined by looking at the shebang line which must match the regular expressions in the table below.
 
-For languages where there could be several entry points, the default
-entry point in the table below will be used.
+For languages where there could be several entry points, the default entry point in the table below will be used.
 
 | Code       | Language    | Default entry point | File endings              | Shebang                                                                                      |
 | ---------- | ----------- | ------------------- | ------------------------- | -------------------------------------------------------------------------------------------- |
@@ -93,24 +82,19 @@ entry point in the table below will be used.
 
 ### Problem types
 
-There are two types of problems: <em>pass-fail</em> problems and
-<em>scoring</em> problems. In pass-fail problems, submissions are
-basically judged as either accepted or rejected (though the "rejected"
-judgement is more fine-grained and divided into results such as "Wrong
-Answer", "Time Limit Exceeded", etc). In scoring problems, a submission
-that is accepted is additionally given a score, which is a numeric value
-(and the goal is to either maximize or minimize this value).
+There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems. 
+In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc). 
+In scoring problems, a submission that is accepted is additionally given a score, which is a numeric value (and the goal is to either maximize or minimize this value).
 
 </div>
 
 ## Problem Metadata
 
-Metadata about the problem (e.g., source, license, limits) are provided
-in a UTF-8 encoded YAML file named `problem.yaml` placed in the root
-directory of the package.
+Metadata about the problem (e.g., source, license, limits) are provided in a UTF-8 encoded YAML file named `problem.yaml` placed in the root directory of the package.
 
-The keys are defined as below. Keys are optional unless explicitly
-stated. Any unknown keys should be treated as an error.
+The keys are defined as below. 
+Keys are optional unless explicitly stated. 
+Any unknown keys should be treated as an error.
 
 | Key                                   | Type                                                          | Default                                                 | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -131,8 +115,7 @@ stated. Any unknown keys should be treated as an error.
 
 Allowed values for license.
 
-Values other than _unknown_ or _public domain_ requires rights_owner to
-have a value.
+Values other than _unknown_ or _public domain_ requires rights_owner to have a value.
 
 | Value         | Comments                                                                     | Link                                             |
 | ------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ |
@@ -162,9 +145,8 @@ A map with the following keys:
 | validation_output  | optional, in MiB     | system default | 8                      |
 
 For most keys the system default will be used if nothing is specified.
-This can vary, but you SHOULD assume that it's reasonable. Only specify
-limits when the problem needs a specific limit, but do specify limits
-even if the "typical system default" is what is needed.
+This can vary, but you SHOULD assume that it's reasonable. 
+Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
 
 <div class="not-icpc">
 
@@ -176,81 +158,65 @@ A map with the following keys:
 | --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
 | objective             | String  | max     | One of "min" or "max" specifying whether it is a minimization or a maximization problem. |
 | show_test_data_groups | boolean | false   | Specifies whether test group results should be shown to the end user.                    |
-|                       |         |         |                                                                                          |
 
 </div>
 
 ## Problem Statements
 
-The problem statement of the problem is provided in the directory
-`problem_statement/`.
+The problem statement of the problem is provided in the directory `problem_statement/`.
 
-This directory must contain one file per language, for at least one
-language, named `problem.`\<language\>`.`\<filetype\>, that contains the
-problem text itself, including input and output specifications, but not
-sample input and output. Language must be given as the
-shortest ISO 639 code. If needed a hyphen and a ISO 3166-1 alpha-2 code
-may be appended to ISO 639 code. Optionally, the language code can
-be left out, the default is then English (`en`). Filetype can be either
-`tex` for LaTeX files, or `pdf` for PDF.
+This directory must contain one file per language, for at least one language, named `problem.`\<language\>`.`\<filetype\>, 
+that contains the problem text itself, including input and output specifications, but not sample input and output. 
+Language must be given as the shortest ISO 639 code. 
+If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code. 
+Optionally, the language code can be left out, the default is then English (`en`). 
+Filetype can be either `tex` for LaTeX files, or `pdf` for PDF.
 
-Please note that many kinds of transformations on the problem statements, such
-as conversion to HTML or styling to fit in a single document containing many
-problems will not be possible for PDF problem statements, so using this
-format should be avoided if at all possible.
+Please note that many kinds of transformations on the problem statements, 
+such as conversion to HTML or styling to fit in a single document containing many problems will not be possible for PDF problem statements, 
+so using this format should be avoided if at all possible.
 
-Auxiliary files needed by the problem statement files must all be in
-`<short_name>/problem_statement/`. `problem.<language>.<filetype>`
-should reference auxiliary files as if the working directory is
-`<short_name>/problem_statement/`. Image file formats supported are
-`.png`, `.jpg`, `.jpeg`, and `.pdf`.
+Auxiliary files needed by the problem statement files must all be in `<short_name>/problem_statement/`. 
+`problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`. 
+Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-A LaTeX file may include the Problem name using the LaTeX command
-`\problemname` in case LaTeX formatting of the title is wanted.
+A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
 
-The problem statements must only contain the actual problem statement,
-no sample data.
+The problem statements must only contain the actual problem statement, no sample data.
 
 ## Attachments
 
-Public, i.e. non-secret, files to be made available in addition to the
-problem statement and sample test data are provided in the directory
-`attachments/`.
+Public, i.e. non-secret, files to be made available in addition to the problem statement and sample test data are provided in the directory `attachments/`.
 
 ## Test data
 
-The test data are provided in subdirectories of `data/`. The sample data
-in `data/sample/` and the secret data in `data/secret/`.
+The test data are provided in subdirectories of `data/`. 
+The sample data in `data/sample/` and the secret data in `data/secret/`.
 
-All input and answer files have the filename extension `.in` and `.ans`
-respectively.
+All input and answer files have the filename extension `.in` and `.ans` respectively.
 
 ### Annotations
 
-Optionally a hint, a description and an illustration file may be
-provided.
+Optionally a hint, a description and an illustration file may be provided.
 
-The hint file is a text file with filename extension`.hint` giving a
-hint for solving an input file. The hint file is meant to be given as
-feedback, i.e. to somebody that fails to solve the problem.
+The hint file is a text file with filename extension`.hint` giving a hint for solving an input file. 
+The hint file is meant to be given as feedback, i.e. to somebody that fails to solve the problem.
 
-The description file is a text file with filename extension `.desc`
-describing the purpose of an input file. The description file is meant
-to be privileged information that explains the purpose of the related
-test file, e.g. what cases it's supposed to test.
+The description file is a text file with filename extension `.desc` describing the purpose of an input file. 
+The description file is meant to be privileged information that explains the purpose of the related test file, e.g. what cases it's supposed to test.
 
-The Illustration is an image file with filename extension `.png`,
-`.jpg`, `.jpeg`, or `.svg`. The illustration is meant to be privileged
-information illustrating the related test file.
+The Illustration is an image file with filename extension `.png`, `.jpg`, `.jpeg`, or `.svg`. 
+The illustration is meant to be privileged information illustrating the related test file.
 
-Input, answer, description, hint and image files are matched by the base
-name.
+Input, answer, description, hint and image files are matched by the base name.
 
 ### Interactive Problems
 
-For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator, meant to be displayed in the problem statement.
+For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator, 
+meant to be displayed in the problem statement. 
 An interaction protocol consists of a series of lines starting with `>` and `<`.
-Lines starting with `>` signify an output from the submission to the output validator, while `<` signify an input from the output validator to the submission.
+Lines starting with `>` signify an output from the submission to the output validator, 
+while `<` signify an input from the output validator to the submission.
 
 A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file.
 However, if either of a `.in` or a `.ans` file is present the other one must also be present.
@@ -261,35 +227,31 @@ If you want to provide files related to interactive problems (such as testing to
 
 <div class="not-icpc">
 
-The test data for the problem can be organized into a tree-like
-structure. Each node of this tree is represented by a directory and
-referred to as a test data group. Each test data group may consist of
-zero or more test cases (i.e., input-answer files) and zero or more
-subgroups of test data (i.e., subdirectories).
+The test data for the problem can be organized into a tree-like structure. 
+Each node of this tree is represented by a directory and referred to as a test data group. 
+Each test data group may consist of zero or more test cases (i.e., input-answer files) and zero or more subgroups of test data (i.e., subdirectories).
 
 </div>
 
-At the top level, the test data is divided into exactly two groups:
-`sample` and `secret`. <span class="not-icpc">These two groups may be further split into subgroups as desired. </span>
+At the top level, the test data is divided into exactly two groups: `sample` and `secret`. 
+<span class="not-icpc">These two groups may be further split into subgroups as desired.</span>
 
 <div class="not-icpc">
 
-The <em>result</em> of a test data group is computed by applying a
-<em>grader</em> to all of the sub-results (test cases and subgroups) in
-the group. See [Graders](#graders "wikilink") for more details.
+The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group. 
+See [Graders](#graders "wikilink") for more details.
 
 </div>
 
-Test files and groups will be used in lexicographical order on file base
-name. If a specific order is desired a numbered prefix such as `00`, `01`,
-`02`, `03`, and so on, can be used.
+Test files and groups will be used in lexicographical order on file base name. 
+If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
 
 <div class="not-icpc">
 
-In each test data group, a file `testdata.yaml` may be placed to specify
-how the result of the test data group should be computed. If such a file
-is not provided for a test data group then the settings for the parent
-group will be used. The format of `testdata.yaml` is as follows:
+In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed. 
+If such a file is not provided for a test data group then the settings for the parent group will be used. 
+
+The format of `testdata.yaml` is as follows:
 
 | Key                    | Type                                           | Default      | Comments                                                                                                                                                                                                                                                                                                          |
 | ---------------------- | ---------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -306,23 +268,20 @@ group will be used. The format of `testdata.yaml` is as follows:
 
 ## Included Code
 
-Code that should be included with all submissions are provided in one
-directory per supported language, called `include/`\<language\>`/`.
+Code that should be included with all submissions are provided in one directory per supported language, called `include/`\<language\>`/`.
 
-The files should be copied from a language directory based on the
-language of the submission, to the submission files before compiling,
-overwriting files from the submission in the case of name collision.
-Language must be given as one of the language codes in the language
-table in the overview section. If any of the included files are supposed
-to be the main file (i.e. a driver), that file must have the language
-dependent name as given in the table referred above.
+The files should be copied from a language directory based on the language of the submission, 
+to the submission files before compiling, overwriting files from the submission in the case of name collision.
+Language must be given as one of the language codes in the language table in the overview section. 
+If any of the included files are supposed to be the main file (i.e. a driver), 
+that file must have the language dependent name as given in the table referred above.
 
 </div>
 
 ## Example Submissions
 
-Correct and incorrect solutions to the problem are provided in
-subdirectories of `submissions/`. The possible subdirectories are:
+Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`. 
+The possible subdirectories are:
 
 | Value                                             | Requirement                                                                                                                                                       | Comment                                                                 |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -332,17 +291,15 @@ subdirectories of `submissions/`. The possible subdirectories are:
 | time_limit_exceeded                               | Too slow for some test file. May also give wrong answer but not crash for any test file.                                                                          |                                                                         |
 | run_time_error                                    | Crashes for some test file                                                                                                                                        |                                                                         |
 
-Every file or directory in these directories represents a separate
-solution. Same requirements as for submissions with regards to
-filenames. It is mandatory to provide at least one accepted solution.
+Every file or directory in these directories represents a separate solution. 
+Same requirements as for submissions with regards to filenames. 
+It is mandatory to provide at least one accepted solution.
 
-Submissions must read input data from standard input, and write output
-to standard output.
+Submissions must read input data from standard input, and write output to standard output.
 
 ## Input Validators
 
-Input Validators, for verifying the correctness of the input files, are
-provided in `input_validators/` (or the deprecated `input_format_validators/`).
+Input Validators, for verifying the correctness of the input files, are provided in `input_validators/` (or the deprecated `input_format_validators/`).
 Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
 
 All input validators provided will be run on every input file.
@@ -350,11 +307,9 @@ Validation fails if any validator fails.
 
 ### Invocation
 
-An input validator program must be an application (executable or
-interpreted) capable of being invoked with a command line call.
+An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
 
-All input validators provided will be run on every test data file using
-the arguments specified for the test data group they are part of.
+All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of.
 Validation fails if any validator fails.
 
 When invoked the input validator will get the input file on stdin.
@@ -366,56 +321,46 @@ The validator should be possible to use as follows on the command line:
 ### Output
 
 The input validator may output debug information on stdout and stderr.
-This information may be displayed to the user upon invocation of the
-validator.
+This information may be displayed to the user upon invocation of the validator.
 
 ### Exit codes
 
-The input validator must exit with code 42 on successful validation. Any
-other exit code means that the input file could not be confirmed as
-valid.
+The input validator must exit with code 42 on successful validation. 
+Any other exit code means that the input file could not be confirmed as valid.
 
 #### Dependencies
 
-The validator MUST NOT read any files outside those defined in the
-Invocation section. Its result MUST depend only on these files and the
-arguments.
+The validator MUST NOT read any files outside those defined in the Invocation section. 
+Its result MUST depend only on these files and the arguments.
 
 ## Output Validators
 
 ### Overview
 
-An output validator is a program that is given the output of a submitted
-program, together with the corresponding input file, and a correct
-answer file for the input, and then decides whether the output provided
-is a correct output for the given input file.
+An output validator is a program that is given the output of a submitted program, 
+together with the corresponding input file, 
+and a correct answer file for the input, 
+and then decides whether the output provided is a correct output for the given input file.
 
-A validator program must be an application (executable or interpreted)
-capable of being invoked with a command line call. The details of this
-invocation are described below. The validator program has two ways of
-reporting back the results of validating:
+A validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
+The details of this invocation are described below. 
+The validator program has two ways of reporting back the results of validating:
 
-1.  The validator must give a judgment (see [Reporting a
-    judgment](#reporting-a-judgment "wikilink")).
-2.  The validator may give additional feedback, e.g., an explanation of
-    the judgment to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
+1.  The validator must give a judgment (see [Reporting a judgment](#reporting-a-judgment "wikilink")).
+2.  The validator may give additional feedback, 
+    e.g., an explanation of the judgment to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
-Custom output Validators are used if the problem requires more complicated
-output validation than what is provided by the default diff variant
-described below. They are provided in `output_validators/`, and must
-adhere to the [Output validator](output_validators "wikilink")
-specification.
+Custom output Validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below. 
+They are provided in `output_validators/`, and must adhere to the [Output validator](output_validators "wikilink") specification.
 
-All output validators provided will be run on the output for every test
-data file using the arguments specified for the test data group they are
-part of. Validation fails if any validator fails.
+All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of. 
+Validation fails if any validator fails.
 
 ### Default Output Validator Specification
 
-The default output validator is essentially a beefed-up diff. In its
-default mode, it tokenizes the files to compare and compares them token
-by token. It supports the following command-line arguments to control
-how tokens are compared.
+The default output validator is essentially a beefed-up diff. 
+In its default mode, it tokenizes the files to compare and compares them token by token. 
+It supports the following command-line arguments to control how tokens are compared.
 
 | Arguments                    | Description                                                                                                                                                 |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -425,19 +370,14 @@ how tokens are compared.
 | `float_absolute_tolerance ε` | indicates that floating-point tokens should be accepted if they are within absolute error ≤ ε (see below for details).                                      |
 | `float_tolerance ε`          | short-hand for applying ε as both relative and absolute tolerance.                                                                                          |
 
-When supplying both a relative and an absolute tolerance, the semantics
-are that a token is accepted if it is within either of the two
-tolerances. When a floating-point tolerance has been set, any valid
-formatting of floating point numbers is accepted for floating point
-tokens. So for instance if a token in the answer file says `0.0314`, a
-token of `3.14000000e-2` in the output file would be accepted. If no
-floating point tolerance has been set, floating point tokens are treated
-just like any other token and has to match exactly.
+When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the two tolerances. 
+When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating point tokens. 
+So for instance if a token in the answer file says `0.0314`, a token of `3.14000000e-2` in the output file would be accepted. 
+If no floating point tolerance has been set, floating point tokens are treated just like any other token and has to match exactly.
 
 ### Invocation
 
-When invoked the output validator will be passed at least three command
-line parameters and the output stream to validate on stdin.
+When invoked the output validator will be passed at least three command line parameters and the output stream to validate on stdin.
 
 The validator should be possible to use as follows on the command line:
 
@@ -447,97 +387,70 @@ The validator should be possible to use as follows on the command line:
 
 The meaning of the parameters listed above are:
 
-- input: a string specifying the name of the input data file which was
-  used to test the program whose results are being validated.
+- input: 
+  a string specifying the name of the input data file which was used to test the program whose results are being validated.
 
-- judge_answer: a string specifying the name of an arbitrary "answer
-  file" which acts as input to the validator program. The answer file
-  may, but is not necessarily required to, contain the "correct
-  answer" for the problem. For example, it might contain the output
-  which was produced by a judge's solution for the problem when run
-  with input file as input. Alternatively, the "answer file" might
-  contain information, in arbitrary format, which instructs the
-  validator in some way about how to accomplish its task. The meaning
-  of the contents of the answer file is not defined by this standard.
+- judge_answer: 
+  a string specifying the name of an arbitrary "answer file" which acts as input to the validator program. 
+  The answer file may, but is not necessarily required to, contain the "correct answer" for the problem. 
+  For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input. 
+  Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task. 
+  The meaning of the contents of the answer file is not defined by this standard.
 
-- feedback_dir: a string which specifies the name of a "feedback
-  directory" in which the validator can produce "feedback files" in
-  order to report additional information on the validation of the
-  output file. The feedbackdir must end with a path separator
-  (typically '/' or '\\' depending on operating system), so that
-  simply appending a filename to feedbackdir gives the path to a file
-  in the feedback directory.
+- feedback_dir: 
+  a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file. 
+  The feedbackdir must end with a path separator (typically '/' or '\\' depending on operating system), 
+  so that simply appending a filename to feedbackdir gives the path to a file in the feedback directory.
 
-- additional_arguments: in case the problem specifies additional
-  validator_flags, these are passed as additional arguments to the
-  validator on the command line.
+- additional_arguments: 
+  in case the problem specifies additional validator_flags, these are passed as additional arguments to the validator on the command line.
 
-- team_output: the output produced by the program being validated is
-  given on the validator's standard input pipe.
+- team_output: 
+  the output produced by the program being validated is given on the validator's standard input pipe.
 
-- team_input: when running the validator in interactive mode
-  everything written on the validator's standard output pipe is given
-  to the program being validated. Please note that when running
-  interactive the program will only receive the output produced by the
-  validator and will not have direct access to the input file.
+- team_input: 
+  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated. 
+  Please note that when running interactive the program will only receive the output produced by the validator and will not have direct access to the input file.
 
-The two files pointed to by input and judge_answer must exist (though
-they are allowed to be empty) and the validator program must be allowed
-to open them for reading. The directory pointed to by feedback_dir must
-also exist.
+The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading. 
+The directory pointed to by feedback_dir must also exist.
 
 ### Reporting a judgment
 
-A validator program is required to report its judgment by exiting with
-specific exit codes:
+A validator program is required to report its judgment by exiting with specific exit codes:
 
-- If the output is a correct output for the input file (i.e., the
-  submission that produced the output is to be Accepted), the
-  validator exits with exit code 42.
-- If the output is incorrect (i.e., the submission that produced the
-  output is to be judged as Wrong Answer), the validator exits with
-  exit code 43.
+- If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted), 
+  the validator exits with exit code 42.
+- If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer), 
+  the validator exits with exit code 43.
 
-Any other exit code (including 0\!) indicates that the validator did not
-operate properly, and the contest control system invoking the validator
-must take measures to report this to contest personnel. The purpose of
-these somewhat exotic exit codes is to avoid conflict with other exit
-codes that results when the validator crashes. For instance, if the
-validator is written in Java, any unhandled exception results in the
-program crashing with an exit code of 1, making it unsuitable to assign
-a judgment meaning to this exit code.
+Any other exit code (including 0\!) indicates that the validator did not operate properly, 
+and the contest control system invoking the validator must take measures to report this to contest personnel. 
+The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
+For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
+making it unsuitable to assign a judgment meaning to this exit code.
 
 ### Reporting Additional Feedback
 
-The purpose of the feedback directory is to allow the validator program
-to report more information to the contest control system than just the
-accept/reject verdict. Using the feedback directory is optional for a
-validator program, so if one just wants to write a bare-bones minimal
-validator, it can be ignored.
+The purpose of the feedback directory is to allow the validator program to report more information to the contest control system than just the accept/reject verdict. 
+Using the feedback directory is optional for a validator program, so if one just wants to write a bare-bones minimal validator, it can be ignored.
 
-The validator is free to create different files in the feedback
-directory, in order to provide different kinds of information to the
-contest control system, in a simple but organized way. For instance,
-there may be a "judgemessage.txt" file, the contents of which gives a
-message that is presented to a judge reviewing the current submission
-(typically used to help the judge verify why the submission was judged
-as incorrect, by specifying exactly what was wrong with its output).
-Other examples of files that may be useful in some contexts (though not
-in the ICPC) are a score.txt file, giving the submission a score based
-on other factors than correctness, or a teammessage.txt file, giving a
-message to the team that submitted the solution, providing additional
-feedback on the submission.
+The validator is free to create different files in the feedback directory, 
+in order to provide different kinds of information to the contest control system, in a simple but organized way. 
+For instance, there may be a "judgemessage.txt" file, 
+the contents of which gives a message that is presented to a judge reviewing the current submission
+(typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
+Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file, 
+giving the submission a score based on other factors than correctness, 
+or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A contest control system that implements this standard must support the
-judgemessage.txt file described above (I.e., content of the
-"judgemessage.txt" file, if produced by the validator, must be provided
-by the contest control system to a human judge examining the
-submission). Having the Contest Control System support other files is
-optional.
+A contest control system that implements this standard must support the judgemessage.txt file described above 
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the contest control system to a human judge examining the
+submission). 
+Having the Contest Control System support other files is optional.
 
-Note that a validator may choose to ignore the feedback directory
-entirely. In particular, the contest control system must not assume that
-the validator program creates any files there at all.
+Note that a validator may choose to ignore the feedback directory entirely. 
+In particular, the contest control system must not assume that the validator program creates any files there at all.
 
 #### Examples
 
@@ -559,33 +472,26 @@ Almost all test cases failed, are you even trying to solve the problem?
 
 #### Validator standard output and standard error
 
-A valididator program is allowed to write any kind of debug information
-to its standard error pipe. This information may be displayed to the
-user upon invocation of the validator.
+A valididator program is allowed to write any kind of debug information to its standard error pipe. 
+This information may be displayed to the user upon invocation of the validator.
 
 <div class="not-icpc">
 
 ## Graders
 
-Graders are programs that are given the sub-results of a test data group
-and aggregate a result for the group. They are provided in `graders/` .
+Graders are programs that are given the sub-results of a test data group and aggregate a result for the group. 
+They are provided in `graders/` .
 
-For pass-fail problems, this grader will typically just set the verdict
-to accepted if all sub-results in the group were accepted and otherwise
-select the "worst" error in the group (see below for definition of
-"worst"), though it is possible to write a custom grader which e.g.
-accepts if at least half the sub-results are accepted. For scoring
-problems, one common grader behaviour would be to always set the verdict
-to Accepted, with the score being the sum of scores of the items in the
-test group.
+For pass-fail problems, this grader will typically just set the verdict to accepted if all sub-results in the group were accepted and otherwise select the "worst" error in the group (see below for definition of "worst"), 
+though it is possible to write a custom grader which e.g. accepts if at least half the sub-results are accepted. 
+For scoring problems, one common grader behaviour would be to always set the verdict to Accepted, 
+with the score being the sum of scores of the items in the test group.
 
 ### Invocation
 
-A grader program must be an application (executable or interpreted)
-capable of being invoked with a command line call.
+A grader program must be an application (executable or interpreted) capable of being invoked with a command line call.
 
-When invoked the grader will get the judgement for test files or groups
-on stdin and is expected to produce an aggregate result on stdout.
+When invoked the grader will get the judgement for test files or groups on stdin and is expected to produce an aggregate result on stdout.
 
 The grader should be possible to use as follows on the command line:
 
@@ -595,11 +501,9 @@ On success, the grader must exit with exit code 0.
 
 ### Input
 
-A grader simply takes a list of results on standard input, and produces
-a single result on standard output. The input file will have the one
-line per test file containing the result of judging the testfile, using
-the code from the table below, followed by whitespace, followed by the
-score.
+A grader simply takes a list of results on standard input, and produces a single result on standard output. 
+The input file will have the one line per test file containing the result of judging the testfile, 
+using the code from the table below, followed by whitespace, followed by the score.
 
 | Code | Meaning             |
 | ---- | ------------------- |
@@ -608,32 +512,29 @@ score.
 | RTE  | Run-Time Error      |
 | TLE  | Time-Limit Exceeded |
 
-The score is taken from the `score.txt` files produced by the output
-validator. If no `score.txt` exists the score will be as defined by the
-grading accept_score and reject_score setting from problem.yaml.
+The score is taken from the `score.txt` files produced by the output validator. 
+If no `score.txt` exists the score will be as defined by the grading accept_score and reject_score setting from problem.yaml.
 
 ### Output
 
-The grader must output the aggregate result on stdout in the same format
-as its input. Any other output, including no output, will result in a
-Judging Error.
+The grader must output the aggregate result on stdout in the same format as its input. 
+Any other output, including no output, will result in a Judging Error.
 
-For pass-fail problems, or for non-Accepted results on scoring problems,
-the score provided by the grader will always be ignored.
+For pass-fail problems, or for non-Accepted results on scoring problems, the score provided by the grader will always be ignored.
 
-The grader may output debug information on stderr. This information may
-be displayed to the user upon invocation of the grader.
+The grader may output debug information on stderr. 
+This information may be displayed to the user upon invocation of the grader.
 
 ### Default Grader Specification
 
-The default grader has three different modes for aggregating the verdict
--- _worst_error_, _first_error_ and _always_accept_ -- four different
-modes for aggregating the score -- _sum_, _avg_, _min_, _max_ -- and two
-flags -- _ignore_sample_ and _accept_if_any_accepted_. These modes
-can be set by providing their names as command line arguments (through
-the "grader_flags" option in
-[testdata.yaml](#test-data-groups "wikilink")). If multiple conflicting
-modes are given, the last one is used. Their meaning are as follows.
+The default grader has three different modes for aggregating the verdict 
+-- _worst_error_, _first_error_ and _always_accept_ -- 
+four different modes for aggregating the score 
+-- _sum_, _avg_, _min_, _max_ -- 
+and two flags 
+-- _ignore_sample_ and _accept_if_any_accepted_. 
+These modes can be set by providing their names as command line arguments (through the "grader_flags" option in [testdata.yaml](#test-data-groups "wikilink")). 
+If multiple conflicting modes are given, the last one is used. Their meaning are as follows.
 
 | Argument                 | Type         | Description                                                                                                                                                                                                                                                                                                    |
 | ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-show_diff_buttons: true
 title: Legacy
+show_diff_buttons: true
 sort: 3
 ---
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -403,7 +403,7 @@ The meaning of the parameters listed above are:
   The answer file may, but is not necessarily required to, contain the "correct answer" for the problem. 
   For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input. 
   Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task. 
-  The meaning of the contents of the answer file is not defined by this standard.
+  The meaning of the contents of the answer file is not defined by this format. 
 
 - feedback_dir: 
   a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file. 
@@ -452,7 +452,7 @@ Other examples of files that may be useful in some contexts (though not in the I
 giving the submission a score based on other factors than correctness, 
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A judging system that implements this standard must support the judgemessage.txt file described above 
+A judging system that implements this format must support the judgemessage.txt file described above 
 (I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission). 
 Having the judging system support other files is optional.
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -7,7 +7,11 @@ sort: 3
 
 # Problem Package Format
 
-This is the `legacy` version of the specification
+This is the `legacy` version of the Kattis problem package format. 
+
+There are two variants of this specification: the Full version, and the ICPC subset. 
+Use the buttons in the sidebar to select one of them. 
+The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>. 
 
 ## Overview
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -433,18 +433,18 @@ A validator program is required to report its judgement by exiting with specific
   the validator exits with exit code 43.
 
 Any other exit code (including 0\!) indicates that the validator did not operate properly, 
-and the contest control system invoking the validator must take measures to report this to contest personnel. 
+and the judging system invoking the validator must take measures to report this to contest personnel. 
 The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
 For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
 making it unsuitable to assign a judgement meaning to this exit code.
 
 ### Reporting Additional Feedback
 
-The purpose of the feedback directory is to allow the validator program to report more information to the contest control system than just the accept/reject verdict. 
+The purpose of the feedback directory is to allow the validator program to report more information to the judging system than just the accept/reject verdict. 
 Using the feedback directory is optional for a validator program, so if one just wants to write a bare-bones minimal validator, it can be ignored.
 
 The validator is free to create different files in the feedback directory, 
-in order to provide different kinds of information to the contest control system, in a simple but organized way. 
+in order to provide different kinds of information to the judging system, in a simple but organized way. 
 For instance, there may be a "judgemessage.txt" file, 
 the contents of which gives a message that is presented to a judge reviewing the current submission 
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
@@ -452,12 +452,12 @@ Other examples of files that may be useful in some contexts (though not in the I
 giving the submission a score based on other factors than correctness, 
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A contest control system that implements this standard must support the judgemessage.txt file described above 
-(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the contest control system to a human judge examining the submission). 
-Having the Contest Control System support other files is optional.
+A judging system that implements this standard must support the judgemessage.txt file described above 
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission). 
+Having the judging system support other files is optional.
 
 Note that a validator may choose to ignore the feedback directory entirely. 
-In particular, the contest control system must not assume that the validator program creates any files there at all.
+In particular, the judging system must not assume that the validator program creates any files there at all.
 
 #### Examples
 


### PR DESCRIPTION
This PR should not contain anything controversial, I will merge it fairly quickly...

- Make front matter and newlines consistent between versions, to simplify diffing
- Copy changes between versions (so that that should be same is).
- Add explanation of the ICPC subset buttons
- Change some terminology:
  - `contest control system` to `judging system`
  - `standard` to `format`