### PR TITLE
Changelog and trailing whitespace fixes

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -7,29 +7,29 @@ sort: 2
 
 # Problem Package Format
 
-This is the `2023-07-draft` version of the Kattis problem package format. 
+This is the `2023-07-draft` version of the Kattis problem package format.
 
-There are two variants of this specification: the Full version, and the ICPC subset. 
-Use the buttons in the sidebar to select one of them. 
-The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>. 
+There are two variants of this specification: the Full version, and the ICPC subset.
+Use the buttons in the sidebar to select one of them.
+The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>.
 
 ## Overview
 
-This document describes the format of a _Kattis problem package_, 
+This document describes the format of a _Kattis problem package_,
 used for distributing and sharing problems for algorithmic programming contests as well as educational use.
 
 ### General Requirements
 
-The package consists of a single directory containing files as described below. 
-The name of the directory must consist solely of lower case letters a-z and digits 0-9. 
+The package consists of a single directory containing files as described below.
+The name of the directory must consist solely of lower case letters a-z and digits 0-9.
 Alternatively it can be a ZIP compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
 
 All file names for files included in the package must match the following regexp:
 
 `[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]`
 
-I.e., it must be of length at least 2, 
-consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore, 
+I.e., it must be of length at least 2,
+consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore,
 but must not begin or end with period, dash or underscore.
 
 All text files for a problem must be UTF-8 encoded and not have a byte order mark.
@@ -39,24 +39,24 @@ All floating point numbers must be given as the external character sequences def
 ### Programs
 
 There are a number of different kinds of programs that may be provided in the problem package: submissions, input validators, and output validators.
-All programs are always represented by a single file or directory. 
-In other words, if a program consists of several files, these must be provided in a single directory. 
+All programs are always represented by a single file or directory.
+In other words, if a program consists of several files, these must be provided in a single directory.
 The name of the program, for the purpose of referring to it within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
-Validators, but not submissions, 
-in the form of a directory may include two POSIX-compliant scripts "build" and "run". 
+Validators, but not submissions,
+in the form of a directory may include two POSIX-compliant scripts "build" and "run".
 If at least one of these two files is included:
 
-1. First, if the `build` script is present, it will be run. 
-   The working directory will be (a copy of) the program directory. 
+1. First, if the `build` script is present, it will be run.
+   The working directory will be (a copy of) the program directory.
    The `run` file must exist after `build` is done.
-2. Then, the `run` file (which now exists) must be executable, 
+2. Then, the `run` file (which now exists) must be executable,
    and will be invoked in the same way as a single file program.
 
-Programs without `build` and `run` scripts are built and run according to what language is used. 
-Language is determined by looking at the file endings. 
-If a single language from the table below can't be determined, building fails. 
+Programs without `build` and `run` scripts are built and run according to what language is used.
+Language is determined by looking at the file endings.
+If a single language from the table below can't be determined, building fails.
 
 For languages where there could be several entry points, the default entry point in the table below will be used.
 
@@ -82,15 +82,15 @@ For languages where there could be several entry points, the default entry point
 | rust       | Rust        |                     | .rs                       |
 | scala      | Scala       |                     | .scala                    |
 
-New in version `2023-07`: `.py` files now default to Python 3, and using shebangs are no longer supported; 
+New in version `2023-07`: `.py` files now default to Python 3, and using shebangs are no longer supported;
 Python 2 has to be explicitly indicated by the `.py2` extension.
 
 <div class="not-icpc">
 
 ### Problem Types
 
-There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems. 
-In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc). 
+There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems.
+In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc).
 In scoring problems, a submission that is accepted is additionally given a score, which is a numeric value (and the goal is to maximize this value).
 
 </div>
@@ -99,9 +99,9 @@ In scoring problems, a submission that is accepted is additionally given a score
 
 Metadata about the problem (e.g., source, license, limits) are provided in a UTF-8 encoded YAML file named `problem.yaml` placed in the root directory of the package.
 
-The keys are defined as below. 
-Keys are optional unless explicitly stated. 
-Any unknown keys should be treated as an error. 
+The keys are defined as below.
+Keys are optional unless explicitly stated.
+Any unknown keys should be treated as an error.
 
 | Key                                     | Type                                                        | Default                                                 | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | --------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -153,8 +153,8 @@ A map with the following keys:
 | validation_memory  | optional, in MiB           | system default | 2048                   |
 | validation_output  | optional, in MiB           | system default | 8                      |
 
-For most keys the system default will be used if nothing is specified. 
-This can vary, but you SHOULD assume that it's reasonable. 
+For most keys the system default will be used if nothing is specified.
+This can vary, but you SHOULD assume that it's reasonable.
 Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
 
 #### Problem Timing
@@ -166,14 +166,14 @@ Only specify limits when the problem needs a specific limit, but do specify limi
 | ac_to_time_limit  | float    | 2.0     |
 | time_limit_to_tle | float    | 1.5     |
 
-The value of `time_limit` is an integer or floating-point problem time limit, in seconds. 
-The time multipliers specify safety margins relative to the slowest accepted submission `T_ac` and fastest time_limit_exceeded submission `T_tle`. 
-The `time_limit` must satisfy `T_ac * ac_to_time_limit <= time_limit` and `time_limit * time_limit_to_tle <= T_tle`. 
+The value of `time_limit` is an integer or floating-point problem time limit, in seconds.
+The time multipliers specify safety margins relative to the slowest accepted submission `T_ac` and fastest time_limit_exceeded submission `T_tle`.
+The `time_limit` must satisfy `T_ac * ac_to_time_limit <= time_limit` and `time_limit * time_limit_to_tle <= T_tle`.
 In these calculations, `T_tle` is treated as infinity if the problem does not provide at least one time_limit_exceeded submission.
 
-If no `time_limit` is provided, the default value is the smallest integer multiple of `time_resolution` that satisfies the above inequalities. 
-It is an error if no such multiple exists. 
-The `time_resolution` key is ignored if the problem provides an explicit time limit (and in particular, the time limit is not required to be a multiple of the resolution). 
+If no `time_limit` is provided, the default value is the smallest integer multiple of `time_resolution` that satisfies the above inequalities.
+It is an error if no such multiple exists.
+The `time_resolution` key is ignored if the problem provides an explicit time limit (and in particular, the time limit is not required to be a multiple of the resolution).
 Since time multipliers are more future-proof than absolute time limits, avoid specifying `time_limit` whenever practical.
 
 Contest systems should make a best effort to respect the problem time limit,
@@ -193,22 +193,22 @@ If a list is given, the problem may only be solved using those programming langu
 
 The problem statement of the problem is provided in the directory `problem_statement/`.
 
-This directory must contain one file per language, for at least one language, named `problem.`\<language\>`.`\<filetype\>, 
-that contains the problem text itself, including input and output specifications, but not sample input and output. 
-Language must be given as the shortest ISO 639 code. 
-If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code. 
-Optionally, the language code can be left out, the default is then English (`en`). 
+This directory must contain one file per language, for at least one language, named `problem.`\<language\>`.`\<filetype\>,
+that contains the problem text itself, including input and output specifications, but not sample input and output.
+Language must be given as the shortest ISO 639 code.
+If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code.
+Optionally, the language code can be left out, the default is then English (`en`).
 Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PDF.
 
-Please note that many kinds of transformations on the problem statements, 
-such as conversion to HTML or styling to fit in a single document containing many problems will not be possible for PDF problem statements, 
+Please note that many kinds of transformations on the problem statements,
+such as conversion to HTML or styling to fit in a single document containing many problems will not be possible for PDF problem statements,
 so using this format should be avoided if at all possible.
 
-Auxiliary files needed by the problem statement files must all be in `<short_name>/problem_statement/`. 
-`problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`. 
+Auxiliary files needed by the problem statement files must all be in `<short_name>/problem_statement/`.
+`problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`.
 Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted. 
+A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
 <span class="not-icpc">If it's not included the problem name specified in `problem.yaml` will be used.</span>
 
 The problem statements must only contain the actual problem statement, no sample data.
@@ -219,7 +219,7 @@ Public, i.e. non-secret, files to be made available in addition to the problem s
 
 ## Test data
 
-The test data are provided in subdirectories of `data/`. 
+The test data are provided in subdirectories of `data/`.
 The sample data in `data/sample/` and the secret data in `data/secret/`.
 
 All input and answer files have the filename extension `.in` and `.ans` respectively.
@@ -228,61 +228,61 @@ All input and answer files have the filename extension `.in` and `.ans` respecti
 
 Optionally a hint, a description and an illustration file may be provided.
 
-The hint file is a text file with filename extension`.hint` giving a hint for solving an input file. 
+The hint file is a text file with filename extension`.hint` giving a hint for solving an input file.
 The hint file is meant to be given as feedback, i.e. to somebody that fails to solve the problem.
 
-The description file is a text file with filename extension `.desc` describing the purpose of an input file. 
+The description file is a text file with filename extension `.desc` describing the purpose of an input file.
 The description file is meant to be privileged information that explains the purpose of the related test file, e.g. what cases it's supposed to test.
 
-The Illustration is an image file with filename extension `.png`, `.jpg`, `.jpeg`, or `.svg`. 
+The Illustration is an image file with filename extension `.png`, `.jpg`, `.jpeg`, or `.svg`.
 The illustration is meant to be privileged information illustrating the related test file.
 
 Input, answer, description, hint and image files are matched by the base name.
 
 ### Interactive Problems
 
-For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator, 
-meant to be displayed in the problem statement. 
-An interaction protocol consists of a series of lines starting with `>` and `<`. 
-Lines starting with `>` signify an output from the submission to the output validator, 
+For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator,
+meant to be displayed in the problem statement.
+An interaction protocol consists of a series of lines starting with `>` and `<`.
+Lines starting with `>` signify an output from the submission to the output validator,
 while `<` signify an input from the output validator to the submission.
 
-A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file. 
-However, if either of a `.in` or a `.ans` file is present the other one must also be present. 
-Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams: 
-not in the problem statement, nor as part of sample input download. 
-If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments). 
+A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file.
+However, if either of a `.in` or a `.ans` file is present the other one must also be present.
+Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams:
+not in the problem statement, nor as part of sample input download.
+If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments).
 
 ### Test Data Groups
 
 <div class="not-icpc">
 
-The test data for the problem can be organized into a tree-like structure. 
-Each node of this tree is represented by a directory and referred to as a test data group. 
+The test data for the problem can be organized into a tree-like structure.
+Each node of this tree is represented by a directory and referred to as a test data group.
 Each test data group may consist of zero or more test cases (i.e., input-answer files) and zero or more subgroups of test data (i.e., subdirectories).
 
 </div>
 
-At the top level, the test data is divided into exactly two groups: `sample` and `secret`. 
+At the top level, the test data is divided into exactly two groups: `sample` and `secret`.
 <span class="not-icpc">These two groups may be further split into subgroups as desired.</span>
 
 <div class="not-icpc">
 
-The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group. 
-See [Graders](#graders "wikilink") for more details. 
+The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group.
+See [Graders](#graders "wikilink") for more details.
 
 </div>
 
-Test files and groups will be used in lexicographical order on file base name. 
-If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used. 
+Test files and groups will be used in lexicographical order on file base name.
+If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
 
 <div class="not-icpc">
 
-In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed. 
-If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used. 
-If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values. 
+In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed.
+If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used.
+If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values.
 
-The format of `testdata.yaml` is as follows: 
+The format of `testdata.yaml` is as follows:
 
 | Key                    | Type                                | Default                 | Comments                                                                                                                                                                                                                                                                                                                                                                              |
 | ---------------------- | ----------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -295,27 +295,27 @@ The format of `testdata.yaml` is as follows:
 ### Invalid Input Files
 
 In the `data/` directory, there may be an `invalid_inputs/` directory containing input files that must be rejected by at least one input validator.
-These are meant to only test the input validators, and are not used for judging. 
-The rejected input files can be organized into a tree-like structure similar to the test data. 
+These are meant to only test the input validators, and are not used for judging.
+The rejected input files can be organized into a tree-like structure similar to the test data.
 <span class="not-icpc"> There may be `testdata.yaml` files within this structure, but they may only contain the key `input_validator_flags`.</span>
 
 <div class="not-icpc">
 
 ## Included Code
 
-Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`. 
+Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`.
 
-The files should be copied from a language directory based on the language of the submission, 
-to the submission files before compiling, overwriting files from the submission in the case of name collision. 
-Language must be given as one of the language codes in the language table in the overview section. 
-If any of the included files are supposed to be the main file (i.e. a driver), 
-that file must have the language dependent name as given in the table referred above. 
+The files should be copied from a language directory based on the language of the submission,
+to the submission files before compiling, overwriting files from the submission in the case of name collision.
+Language must be given as one of the language codes in the language table in the overview section.
+If any of the included files are supposed to be the main file (i.e. a driver),
+that file must have the language dependent name as given in the table referred above.
 
 </div>
 
 ## Example Submissions
 
-Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`. 
+Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`.
 The possible subdirectories are:
 
 | Value                                             | Requirement                                                                                                   | Comment                                                                 |
@@ -326,63 +326,63 @@ The possible subdirectories are:
 | time_limit_exceeded                               | Too slow for some test file. May also give wrong answer but not crash for any test file.                      |
 | run_time_error                                    | Crashes for some test file                                                                                    |
 
-Every file or directory in these directories represents a separate solution. 
-Same requirements as for submissions with regards to filenames. 
-It is mandatory to provide at least one accepted solution. 
+Every file or directory in these directories represents a separate solution.
+Same requirements as for submissions with regards to filenames.
+It is mandatory to provide at least one accepted solution.
 
-Submissions must read input data from standard input, and write output to standard output. 
+Submissions must read input data from standard input, and write output to standard output.
 
 ## Input Validators
 
-Input Validators, for verifying the correctness of the input files, are provided in `input_validators/`. 
-Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program. 
+Input Validators, for verifying the correctness of the input files, are provided in `input_validators/`.
+Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
 
-All input validators provided will be run on every input file. 
-Validation fails if any validator fails. 
+All input validators provided will be run on every input file.
+Validation fails if any validator fails.
 
 ### Invocation
 
-An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
+An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
 
-All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of. 
-Validation fails if any validator fails. 
+All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of.
+Validation fails if any validator fails.
 
-When invoked the input validator will get the input file on stdin. 
+When invoked the input validator will get the input file on stdin.
 
-The validator should be possible to use as follows on the command line: 
+The validator should be possible to use as follows on the command line:
 
 `./validator [arguments] < inputfile`
 
 ### Output
 
-The input validator may output debug information on stdout and stderr. 
-This information may be displayed to the user upon invocation of the validator. 
+The input validator may output debug information on stdout and stderr.
+This information may be displayed to the user upon invocation of the validator.
 
 ### Exit codes
 
-The input validator must exit with code 42 on successful validation. 
-Any other exit code means that the input file could not be confirmed as valid. 
+The input validator must exit with code 42 on successful validation.
+Any other exit code means that the input file could not be confirmed as valid.
 
 #### Dependencies
 
-The validator MUST NOT read any files outside those defined in the Invocation section. 
-Its result MUST depend only on these files and the arguments. 
+The validator MUST NOT read any files outside those defined in the Invocation section.
+Its result MUST depend only on these files and the arguments.
 
 ## Output Validator
 
 ### Overview
 
-An output validator is a program that is given the output of a submitted program, 
-together with the corresponding input file, 
-and a correct answer file for the input, 
+An output validator is a program that is given the output of a submitted program,
+together with the corresponding input file,
+and a correct answer file for the input,
 and then decides whether the output provided is a correct output for the given input file.
 
-A validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
-The details of this invocation are described below. 
+A validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
+The details of this invocation are described below.
 The validator program has two ways of reporting back the results of validating:
 
 1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
-2.  The validator may give additional feedback, 
+2.  The validator may give additional feedback,
     e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
 A custom output validator is used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
@@ -393,8 +393,8 @@ It must adhere to the Output validator specification described below.
 
 ### Default Output Validator Specification
 
-The default output validator is essentially a beefed-up diff. 
-In its default mode, it tokenizes the files to compare and compares them token by token. 
+The default output validator is essentially a beefed-up diff.
+In its default mode, it tokenizes the files to compare and compares them token by token.
 It supports the following command-line arguments to control how tokens are compared.
 
 | Arguments                    | Description                                                                                                                                                 |
@@ -405,9 +405,9 @@ It supports the following command-line arguments to control how tokens are compa
 | `float_absolute_tolerance ε` | indicates that floating-point tokens should be accepted if they are within absolute error ≤ ε (see below for details).                                      |
 | `float_tolerance ε`          | short-hand for applying ε as both relative and absolute tolerance.                                                                                          |
 
-When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the two tolerances. 
-When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating point tokens. 
-So for instance if a token in the answer file says `0.0314`, a token of `3.14000000e-2` in the output file would be accepted. 
+When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the two tolerances.
+When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating point tokens.
+So for instance if a token in the answer file says `0.0314`, a token of `3.14000000e-2` in the output file would be accepted.
 If no floating point tolerance has been set, floating point tokens are treated just like any other token and has to match exactly.
 
 ### Invocation
@@ -422,75 +422,75 @@ The validator should be possible to use as follows on the command line:
 
 The meaning of the parameters listed above are:
 
-- input: 
+- input:
   a string specifying the name of the input data file which was used to test the program whose results are being validated.
 
-- judge_answer: 
-  a string specifying the name of an arbitrary "answer file" which acts as input to the validator program. 
-  The answer file may, but is not necessarily required to, contain the "correct answer" for the problem. 
-  For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input. 
-  Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task. 
-  The meaning of the contents of the answer file is not defined by this format. 
+- judge_answer:
+  a string specifying the name of an arbitrary "answer file" which acts as input to the validator program.
+  The answer file may, but is not necessarily required to, contain the "correct answer" for the problem.
+  For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input.
+  Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task.
+  The meaning of the contents of the answer file is not defined by this format.
 
-- feedback_dir: 
-  a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file. 
-  The feedbackdir must end with a path separator (typically '/' or '\\' depending on operating system), 
+- feedback_dir:
+  a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file.
+  The feedbackdir must end with a path separator (typically '/' or '\\' depending on operating system),
   so that simply appending a filename to feedbackdir gives the path to a file in the feedback directory.
 
-- additional_arguments: 
+- additional_arguments:
   in case the problem specifies additional validator_flags, these are passed as additional arguments to the validator on the command line.
 
-- team_output: 
+- team_output:
   the output produced by the program being validated is given on the validator's standard input pipe.
 
-- team_input: 
-  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated. 
+- team_input:
+  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated.
   Please note that when running interactive the program will only receive the output produced by the validator and will not have direct access to the input file.
 
-The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading. 
+The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading.
 The directory pointed to by feedback_dir must also exist.
 
 ### Reporting a judgement
 
 A validator program is required to report its judgement by exiting with specific exit codes:
 
-- If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted), 
+- If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted),
   the validator exits with exit code 42.
-- If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer), 
+- If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer),
   the validator exits with exit code 43.
 
-Any other exit code (including 0\!) indicates that the validator did not operate properly, 
-and the judging system invoking the validator must take measures to report this to contest personnel. 
-The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
-For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
+Any other exit code (including 0\!) indicates that the validator did not operate properly,
+and the judging system invoking the validator must take measures to report this to contest personnel.
+The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes.
+For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1,
 making it unsuitable to assign a judgement meaning to this exit code.
 
 ### Reporting Additional Feedback
 
-The purpose of the feedback directory is to allow the validator program to report more information to the judging system than just the accept/reject verdict. 
+The purpose of the feedback directory is to allow the validator program to report more information to the judging system than just the accept/reject verdict.
 Using the feedback directory is optional for a validator program, so if one just wants to write a bare-bones minimal validator, it can be ignored.
 
-The validator is free to create different files in the feedback directory, 
-in order to provide different kinds of information to the judging system, in a simple but organized way. 
-For instance, there may be a "judgemessage.txt" file, 
-the contents of which gives a message that is presented to a judge reviewing the current submission 
+The validator is free to create different files in the feedback directory,
+in order to provide different kinds of information to the judging system, in a simple but organized way.
+For instance, there may be a "judgemessage.txt" file,
+the contents of which gives a message that is presented to a judge reviewing the current submission
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
-Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file, 
-giving the submission a score based on other factors than correctness, 
+Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file,
+giving the submission a score based on other factors than correctness,
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A judging system that implements this format must support the judgemessage.txt file described above 
-(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission). 
+A judging system that implements this format must support the judgemessage.txt file described above
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission).
 Having the judging system support other files is optional.
 
-Note that a validator may choose to ignore the feedback directory entirely. 
+Note that a validator may choose to ignore the feedback directory entirely.
 In particular, the judging system must not assume that the validator program creates any files there at all.
 
 <div class="not-icpc">
 
 #### Multi-pass validation
 
-A multi-pass validator can be used for problems that should run the submission multiple times sequentially, 
+A multi-pass validator can be used for problems that should run the submission multiple times sequentially,
 using a new input generated by output validator during the previous invocation of the submission.
 
 To signal that the submission should be run again, the output validator must exit with code 42 and output the new input in the file `nextpass.in` in the feedback directory.
@@ -520,13 +520,13 @@ Almost all test cases failed, are you even trying to solve the problem?
 
 #### Validator standard output and standard error
 
-A validator program is allowed to write any kind of debug information to its standard error pipe. 
-This information may be displayed to the user upon invocation of the validator. 
+A validator program is allowed to write any kind of debug information to its standard error pipe.
+This information may be displayed to the user upon invocation of the validator.
 
 ## Grading
 
-For pass-fail problems, the verdict of a submission is the first non-accepted verdict, 
-where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order). 
+For pass-fail problems, the verdict of a submission is the first non-accepted verdict,
+where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order).
 
 <div class="not-icpc">
 

--- a/spec/changelog.md
+++ b/spec/changelog.md
@@ -29,8 +29,6 @@ sort: 1
 - Add support for Markdown problem statements.
 - Change `languages:` and `keywords:` in `problem.yaml` to be lists of strings
   rather than a string of space separated words.
-- Only allow a single output validator.
-- Remove `validator_flags` from problem.yaml.
 
 ## Legacy version (changes since beginning 2021)
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -7,29 +7,29 @@ sort: 3
 
 # Problem Package Format
 
-This is the `legacy` version of the Kattis problem package format. 
+This is the `legacy` version of the Kattis problem package format.
 
-There are two variants of this specification: the Full version, and the ICPC subset. 
-Use the buttons in the sidebar to select one of them. 
-The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>. 
+There are two variants of this specification: the Full version, and the ICPC subset.
+Use the buttons in the sidebar to select one of them.
+The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>.
 
 ## Overview
 
-This document describes the format of a _Kattis problem package_, 
+This document describes the format of a _Kattis problem package_,
 used for distributing and sharing problems for algorithmic programming contests as well as educational use.
 
 ### General Requirements
 
-The package consists of a single directory containing files as described below. 
-The name of the directory must consist solely of lower case letters a-z and digits 0-9. 
+The package consists of a single directory containing files as described below.
+The name of the directory must consist solely of lower case letters a-z and digits 0-9.
 Alternatively it can be a ZIP compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
 
 All file names for files included in the package must match the following regexp:
 
 `[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]`
 
-I.e., it must be of length at least 2, 
-consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore, 
+I.e., it must be of length at least 2,
+consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore,
 but must not begin or end with period, dash or underscore.
 
 All text files for a problem must be UTF-8 encoded and not have a byte order mark.
@@ -39,25 +39,25 @@ All floating point numbers must be given as the external character sequences def
 ### Programs
 
 There are a number of different kinds of programs that may be provided in the problem package; submissions, input validators, output validators<span class="not-icpc">, and graders</span>.
-All programs are always represented by a single file or directory. 
-In other words, if a program consists of several files, these must be provided in a single directory. 
+All programs are always represented by a single file or directory.
+In other words, if a program consists of several files, these must be provided in a single directory.
 The name of the program, for the purpose of referring to it within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
-Validators and graders, but not submissions, 
-in the form of a directory may include two POSIX-compliant scripts "build" and "run". 
+Validators and graders, but not submissions,
+in the form of a directory may include two POSIX-compliant scripts "build" and "run".
 If at least one of these two files is included:
 
-1. First, if the `build` script is present, it will be run. 
-   The working directory will be (a copy of) the program directory. 
+1. First, if the `build` script is present, it will be run.
+   The working directory will be (a copy of) the program directory.
    The `run` file must exist after `build` is done.
-2. Then, the `run` file (which now exists) must be executable, 
+2. Then, the `run` file (which now exists) must be executable,
    and will be invoked in the same way as a single file program.
 
-Programs without `build` and `run` scripts are built and run according to what language is used. 
-Language is determined by looking at the file endings. 
-If a single language from the table below can't be determined, building fails. 
-In the case of Python 2 and 3 which share the same file ending, 
+Programs without `build` and `run` scripts are built and run according to what language is used.
+Language is determined by looking at the file endings.
+If a single language from the table below can't be determined, building fails.
+In the case of Python 2 and 3 which share the same file ending,
 language will be determined by looking at the shebang line which must match the regular expressions in the table below.
 
 For languages where there could be several entry points, the default entry point in the table below will be used.
@@ -88,8 +88,8 @@ For languages where there could be several entry points, the default entry point
 
 ### Problem Types
 
-There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems. 
-In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc). 
+There are two types of problems: <em>pass-fail</em> problems and <em>scoring</em> problems.
+In pass-fail problems, submissions are basically judged as either accepted or rejected (though the "rejected" judgement is more fine-grained and divided into results such as "Wrong Answer", "Time Limit Exceeded", etc).
 In scoring problems, a submission that is accepted is additionally given a score, which is a numeric value (and the goal is to either maximize or minimize this value).
 
 </div>
@@ -98,9 +98,9 @@ In scoring problems, a submission that is accepted is additionally given a score
 
 Metadata about the problem (e.g., source, license, limits) are provided in a UTF-8 encoded YAML file named `problem.yaml` placed in the root directory of the package.
 
-The keys are defined as below. 
-Keys are optional unless explicitly stated. 
-Any unknown keys should be treated as an error. 
+The keys are defined as below.
+Keys are optional unless explicitly stated.
+Any unknown keys should be treated as an error.
 
 | Key                                   | Type                                                          | Default                                                 | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -150,8 +150,8 @@ A map with the following keys:
 | validation_memory  | optional, in MiB     | system default | 2048                   |
 | validation_output  | optional, in MiB     | system default | 8                      |
 
-For most keys the system default will be used if nothing is specified. 
-This can vary, but you SHOULD assume that it's reasonable. 
+For most keys the system default will be used if nothing is specified.
+This can vary, but you SHOULD assume that it's reasonable.
 Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
 
 <div class="not-icpc">
@@ -171,22 +171,22 @@ A map with the following keys:
 
 The problem statement of the problem is provided in the directory `problem_statement/`.
 
-This directory must contain one file per language, for at least one language, named `problem.`\<language\>`.`\<filetype\>, 
-that contains the problem text itself, including input and output specifications, but not sample input and output. 
-Language must be given as the shortest ISO 639 code. 
-If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code. 
-Optionally, the language code can be left out, the default is then English (`en`). 
+This directory must contain one file per language, for at least one language, named `problem.`\<language\>`.`\<filetype\>,
+that contains the problem text itself, including input and output specifications, but not sample input and output.
+Language must be given as the shortest ISO 639 code.
+If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code.
+Optionally, the language code can be left out, the default is then English (`en`).
 Filetype can be either `tex` for LaTeX files, or `pdf` for PDF.
 
-Please note that many kinds of transformations on the problem statements, 
-such as conversion to HTML or styling to fit in a single document containing many problems will not be possible for PDF problem statements, 
+Please note that many kinds of transformations on the problem statements,
+such as conversion to HTML or styling to fit in a single document containing many problems will not be possible for PDF problem statements,
 so using this format should be avoided if at all possible.
 
-Auxiliary files needed by the problem statement files must all be in `<short_name>/problem_statement/`. 
-`problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`. 
+Auxiliary files needed by the problem statement files must all be in `<short_name>/problem_statement/`.
+`problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `<short_name>/problem_statement/`.
 Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted. 
+A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
 
 The problem statements must only contain the actual problem statement, no sample data.
 
@@ -196,7 +196,7 @@ Public, i.e. non-secret, files to be made available in addition to the problem s
 
 ## Test data
 
-The test data are provided in subdirectories of `data/`. 
+The test data are provided in subdirectories of `data/`.
 The sample data in `data/sample/` and the secret data in `data/secret/`.
 
 All input and answer files have the filename extension `.in` and `.ans` respectively.
@@ -205,61 +205,61 @@ All input and answer files have the filename extension `.in` and `.ans` respecti
 
 Optionally a hint, a description and an illustration file may be provided.
 
-The hint file is a text file with filename extension`.hint` giving a hint for solving an input file. 
+The hint file is a text file with filename extension`.hint` giving a hint for solving an input file.
 The hint file is meant to be given as feedback, i.e. to somebody that fails to solve the problem.
 
-The description file is a text file with filename extension `.desc` describing the purpose of an input file. 
+The description file is a text file with filename extension `.desc` describing the purpose of an input file.
 The description file is meant to be privileged information that explains the purpose of the related test file, e.g. what cases it's supposed to test.
 
-The Illustration is an image file with filename extension `.png`, `.jpg`, `.jpeg`, or `.svg`. 
+The Illustration is an image file with filename extension `.png`, `.jpg`, `.jpeg`, or `.svg`.
 The illustration is meant to be privileged information illustrating the related test file.
 
 Input, answer, description, hint and image files are matched by the base name.
 
 ### Interactive Problems
 
-For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator, 
-meant to be displayed in the problem statement. 
-An interaction protocol consists of a series of lines starting with `>` and `<`. 
-Lines starting with `>` signify an output from the submission to the output validator, 
+For interactive problems, any sample test cases must provide an interaction protocol with the extension `.interaction` for each sample demonstrating the communication between the submission and the output validator,
+meant to be displayed in the problem statement.
+An interaction protocol consists of a series of lines starting with `>` and `<`.
+Lines starting with `>` signify an output from the submission to the output validator,
 while `<` signify an input from the output validator to the submission.
 
-A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file. 
-However, if either of a `.in` or a `.ans` file is present the other one must also be present. 
-Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams: 
-not in the problem statement, nor as part of sample input download. 
-If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments). 
+A sample test case may have just an `.interaction` file without a corresponding `.in` and `.ans` file.
+However, if either of a `.in` or a `.ans` file is present the other one must also be present.
+Unlike `.in` and `.ans` files for non-interactive problem, interactive `.in` and `.ans` files must not be displayed to teams:
+not in the problem statement, nor as part of sample input download.
+If you want to provide files related to interactive problems (such as testing tools or input files) you can use [attachments](#attachments).
 
 ### Test Data Groups
 
 <div class="not-icpc">
 
-The test data for the problem can be organized into a tree-like structure. 
-Each node of this tree is represented by a directory and referred to as a test data group. 
+The test data for the problem can be organized into a tree-like structure.
+Each node of this tree is represented by a directory and referred to as a test data group.
 Each test data group may consist of zero or more test cases (i.e., input-answer files) and zero or more subgroups of test data (i.e., subdirectories).
 
 </div>
 
-At the top level, the test data is divided into exactly two groups: `sample` and `secret`. 
+At the top level, the test data is divided into exactly two groups: `sample` and `secret`.
 <span class="not-icpc">These two groups may be further split into subgroups as desired.</span>
 
 <div class="not-icpc">
 
-The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group. 
-See [Graders](#graders "wikilink") for more details. 
+The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group.
+See [Graders](#graders "wikilink") for more details.
 
 </div>
 
-Test files and groups will be used in lexicographical order on file base name. 
-If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used. 
+Test files and groups will be used in lexicographical order on file base name.
+If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
 
 <div class="not-icpc">
 
-In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed. 
-If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used. 
-If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values. 
+In each test data group, a file `testdata.yaml` may be placed to specify how the result of the test data group should be computed.
+If a test data group has no `testdata.yaml` file, the `testdata.yaml` in the closest ancestor group that has one will be used.
+If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values.
 
-The format of `testdata.yaml` is as follows: 
+The format of `testdata.yaml` is as follows:
 
 | Key                    | Type                                           | Default      | Comments                                                                                                                                                                                                                                                                                                          |
 | ---------------------- | ---------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -278,19 +278,19 @@ The format of `testdata.yaml` is as follows:
 
 ## Included Code
 
-Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`. 
+Code that should be included with all submissions are provided in one directory per supported language, called `include/<language>/`.
 
-The files should be copied from a language directory based on the language of the submission, 
-to the submission files before compiling, overwriting files from the submission in the case of name collision. 
-Language must be given as one of the language codes in the language table in the overview section. 
-If any of the included files are supposed to be the main file (i.e. a driver), 
-that file must have the language dependent name as given in the table referred above. 
+The files should be copied from a language directory based on the language of the submission,
+to the submission files before compiling, overwriting files from the submission in the case of name collision.
+Language must be given as one of the language codes in the language table in the overview section.
+If any of the included files are supposed to be the main file (i.e. a driver),
+that file must have the language dependent name as given in the table referred above.
 
 </div>
 
 ## Example Submissions
 
-Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`. 
+Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`.
 The possible subdirectories are:
 
 | Value                                             | Requirement                                                                                                                                                       | Comment                                                                 |
@@ -301,75 +301,75 @@ The possible subdirectories are:
 | time_limit_exceeded                               | Too slow for some test file. May also give wrong answer but not crash for any test file.                                                                          |                                                                         |
 | run_time_error                                    | Crashes for some test file                                                                                                                                        |                                                                         |
 
-Every file or directory in these directories represents a separate solution. 
-Same requirements as for submissions with regards to filenames. 
-It is mandatory to provide at least one accepted solution. 
+Every file or directory in these directories represents a separate solution.
+Same requirements as for submissions with regards to filenames.
+It is mandatory to provide at least one accepted solution.
 
-Submissions must read input data from standard input, and write output to standard output. 
+Submissions must read input data from standard input, and write output to standard output.
 
 ## Input Validators
 
-Input Validators, for verifying the correctness of the input files, are provided in `input_validators/` (or the deprecated `input_format_validators/`). 
-Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program. 
+Input Validators, for verifying the correctness of the input files, are provided in `input_validators/` (or the deprecated `input_format_validators/`).
+Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
 
-All input validators provided will be run on every input file. 
-Validation fails if any validator fails. 
+All input validators provided will be run on every input file.
+Validation fails if any validator fails.
 
 ### Invocation
 
-An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
+An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
 
-All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of. 
-Validation fails if any validator fails. 
+All input validators provided will be run on every test data file using the arguments specified for the test data group they are part of.
+Validation fails if any validator fails.
 
-When invoked the input validator will get the input file on stdin. 
+When invoked the input validator will get the input file on stdin.
 
-The validator should be possible to use as follows on the command line: 
+The validator should be possible to use as follows on the command line:
 
 `./validator [arguments] < inputfile`
 
 ### Output
 
-The input validator may output debug information on stdout and stderr. 
-This information may be displayed to the user upon invocation of the validator. 
+The input validator may output debug information on stdout and stderr.
+This information may be displayed to the user upon invocation of the validator.
 
 ### Exit codes
 
-The input validator must exit with code 42 on successful validation. 
-Any other exit code means that the input file could not be confirmed as valid. 
+The input validator must exit with code 42 on successful validation.
+Any other exit code means that the input file could not be confirmed as valid.
 
 #### Dependencies
 
-The validator MUST NOT read any files outside those defined in the Invocation section. 
-Its result MUST depend only on these files and the arguments. 
+The validator MUST NOT read any files outside those defined in the Invocation section.
+Its result MUST depend only on these files and the arguments.
 
 ## Output Validators
 
 ### Overview
 
-An output validator is a program that is given the output of a submitted program, 
-together with the corresponding input file, 
-and a correct answer file for the input, 
+An output validator is a program that is given the output of a submitted program,
+together with the corresponding input file,
+and a correct answer file for the input,
 and then decides whether the output provided is a correct output for the given input file.
 
-A validator program must be an application (executable or interpreted) capable of being invoked with a command line call. 
-The details of this invocation are described below. 
+A validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
+The details of this invocation are described below.
 The validator program has two ways of reporting back the results of validating:
 
 1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
-2.  The validator may give additional feedback, 
+2.  The validator may give additional feedback,
     e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
-Custom output Validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below. 
+Custom output Validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
 They are provided in `output_validators/`, and must adhere to the [Output validator](output_validators "wikilink") specification.
 
-All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of. 
+All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of.
 Validation fails if any validator fails.
 
 ### Default Output Validator Specification
 
-The default output validator is essentially a beefed-up diff. 
-In its default mode, it tokenizes the files to compare and compares them token by token. 
+The default output validator is essentially a beefed-up diff.
+In its default mode, it tokenizes the files to compare and compares them token by token.
 It supports the following command-line arguments to control how tokens are compared.
 
 | Arguments                    | Description                                                                                                                                                 |
@@ -380,9 +380,9 @@ It supports the following command-line arguments to control how tokens are compa
 | `float_absolute_tolerance ε` | indicates that floating-point tokens should be accepted if they are within absolute error ≤ ε (see below for details).                                      |
 | `float_tolerance ε`          | short-hand for applying ε as both relative and absolute tolerance.                                                                                          |
 
-When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the two tolerances. 
-When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating point tokens. 
-So for instance if a token in the answer file says `0.0314`, a token of `3.14000000e-2` in the output file would be accepted. 
+When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the two tolerances.
+When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating point tokens.
+So for instance if a token in the answer file says `0.0314`, a token of `3.14000000e-2` in the output file would be accepted.
 If no floating point tolerance has been set, floating point tokens are treated just like any other token and has to match exactly.
 
 ### Invocation
@@ -397,68 +397,68 @@ The validator should be possible to use as follows on the command line:
 
 The meaning of the parameters listed above are:
 
-- input: 
+- input:
   a string specifying the name of the input data file which was used to test the program whose results are being validated.
 
-- judge_answer: 
-  a string specifying the name of an arbitrary "answer file" which acts as input to the validator program. 
-  The answer file may, but is not necessarily required to, contain the "correct answer" for the problem. 
-  For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input. 
-  Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task. 
-  The meaning of the contents of the answer file is not defined by this format. 
+- judge_answer:
+  a string specifying the name of an arbitrary "answer file" which acts as input to the validator program.
+  The answer file may, but is not necessarily required to, contain the "correct answer" for the problem.
+  For example, it might contain the output which was produced by a judge's solution for the problem when run with input file as input.
+  Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task.
+  The meaning of the contents of the answer file is not defined by this format.
 
-- feedback_dir: 
-  a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file. 
-  The feedbackdir must end with a path separator (typically '/' or '\\' depending on operating system), 
+- feedback_dir:
+  a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file.
+  The feedbackdir must end with a path separator (typically '/' or '\\' depending on operating system),
   so that simply appending a filename to feedbackdir gives the path to a file in the feedback directory.
 
-- additional_arguments: 
+- additional_arguments:
   in case the problem specifies additional validator_flags, these are passed as additional arguments to the validator on the command line.
 
-- team_output: 
+- team_output:
   the output produced by the program being validated is given on the validator's standard input pipe.
 
-- team_input: 
-  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated. 
+- team_input:
+  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated.
   Please note that when running interactive the program will only receive the output produced by the validator and will not have direct access to the input file.
 
-The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading. 
+The two files pointed to by input and judge_answer must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading.
 The directory pointed to by feedback_dir must also exist.
 
 ### Reporting a judgement
 
 A validator program is required to report its judgement by exiting with specific exit codes:
 
-- If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted), 
+- If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted),
   the validator exits with exit code 42.
-- If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer), 
+- If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer),
   the validator exits with exit code 43.
 
-Any other exit code (including 0\!) indicates that the validator did not operate properly, 
-and the judging system invoking the validator must take measures to report this to contest personnel. 
-The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes. 
-For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1, 
+Any other exit code (including 0\!) indicates that the validator did not operate properly,
+and the judging system invoking the validator must take measures to report this to contest personnel.
+The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes.
+For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1,
 making it unsuitable to assign a judgement meaning to this exit code.
 
 ### Reporting Additional Feedback
 
-The purpose of the feedback directory is to allow the validator program to report more information to the judging system than just the accept/reject verdict. 
+The purpose of the feedback directory is to allow the validator program to report more information to the judging system than just the accept/reject verdict.
 Using the feedback directory is optional for a validator program, so if one just wants to write a bare-bones minimal validator, it can be ignored.
 
-The validator is free to create different files in the feedback directory, 
-in order to provide different kinds of information to the judging system, in a simple but organized way. 
-For instance, there may be a "judgemessage.txt" file, 
-the contents of which gives a message that is presented to a judge reviewing the current submission 
+The validator is free to create different files in the feedback directory,
+in order to provide different kinds of information to the judging system, in a simple but organized way.
+For instance, there may be a "judgemessage.txt" file,
+the contents of which gives a message that is presented to a judge reviewing the current submission
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
-Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file, 
-giving the submission a score based on other factors than correctness, 
+Other examples of files that may be useful in some contexts (though not in the ICPC) are a score.txt file,
+giving the submission a score based on other factors than correctness,
 or a teammessage.txt file, giving a message to the team that submitted the solution, providing additional feedback on the submission.
 
-A judging system that implements this format must support the judgemessage.txt file described above 
-(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission). 
+A judging system that implements this format must support the judgemessage.txt file described above
+(I.e., content of the "judgemessage.txt" file, if produced by the validator, must be provided by the judging system to a human judge examining the submission).
 Having the judging system support other files is optional.
 
-Note that a validator may choose to ignore the feedback directory entirely. 
+Note that a validator may choose to ignore the feedback directory entirely.
 In particular, the judging system must not assume that the validator program creates any files there at all.
 
 #### Examples
@@ -481,20 +481,20 @@ Almost all test cases failed, are you even trying to solve the problem?
 
 #### Validator standard output and standard error
 
-A validator program is allowed to write any kind of debug information to its standard error pipe. 
-This information may be displayed to the user upon invocation of the validator. 
+A validator program is allowed to write any kind of debug information to its standard error pipe.
+This information may be displayed to the user upon invocation of the validator.
 
 <div class="not-icpc">
 
 ## Graders
 
-Graders are programs that are given the sub-results of a test data group and aggregate a result for the group. 
-They are provided in `graders/`. 
+Graders are programs that are given the sub-results of a test data group and aggregate a result for the group.
+They are provided in `graders/`.
 
-For pass-fail problems, this grader will typically just set the verdict to accepted if all sub-results in the group were accepted and otherwise select the "worst" error in the group (see below for definition of "worst"), 
-though it is possible to write a custom grader which e.g. accepts if at least half the sub-results are accepted. 
-For scoring problems, one common grader behaviour would be to always set the verdict to Accepted, 
-with the score being the sum of scores of the items in the test group. 
+For pass-fail problems, this grader will typically just set the verdict to accepted if all sub-results in the group were accepted and otherwise select the "worst" error in the group (see below for definition of "worst"),
+though it is possible to write a custom grader which e.g. accepts if at least half the sub-results are accepted.
+For scoring problems, one common grader behaviour would be to always set the verdict to Accepted,
+with the score being the sum of scores of the items in the test group.
 
 ### Invocation
 
@@ -510,8 +510,8 @@ On success, the grader must exit with exit code 0.
 
 ### Input
 
-A grader simply takes a list of results on standard input, and produces a single result on standard output. 
-The input file will have the one line per test file containing the result of judging the testfile, 
+A grader simply takes a list of results on standard input, and produces a single result on standard output.
+The input file will have the one line per test file containing the result of judging the testfile,
 using the code from the table below, followed by whitespace, followed by the score.
 
 | Code | Meaning             |
@@ -521,28 +521,28 @@ using the code from the table below, followed by whitespace, followed by the sco
 | RTE  | Run-Time Error      |
 | TLE  | Time-Limit Exceeded |
 
-The score is taken from the `score.txt` files produced by the output validator. 
+The score is taken from the `score.txt` files produced by the output validator.
 If no `score.txt` exists the score will be as defined by the grading accept_score and reject_score setting from problem.yaml.
 
 ### Output
 
-The grader must output the aggregate result on stdout in the same format as its input. 
+The grader must output the aggregate result on stdout in the same format as its input.
 Any other output, including no output, will result in a Judging Error.
 
 For pass-fail problems, or for non-Accepted results on scoring problems, the score provided by the grader will always be ignored.
 
-The grader may output debug information on stderr. 
+The grader may output debug information on stderr.
 This information may be displayed to the user upon invocation of the grader.
 
 ### Default Grader Specification
 
-The default grader has three different modes for aggregating the verdict 
--- _worst_error_, _first_error_ and _always_accept_ -- 
-four different modes for aggregating the score 
--- _sum_, _avg_, _min_, _max_ -- 
-and two flags 
--- _ignore_sample_ and _accept_if_any_accepted_. 
-These modes can be set by providing their names as command line arguments (through the "grader_flags" option in [testdata.yaml](#test-data-groups "wikilink")). 
+The default grader has three different modes for aggregating the verdict
+-- _worst_error_, _first_error_ and _always_accept_ --
+four different modes for aggregating the score
+-- _sum_, _avg_, _min_, _max_ --
+and two flags
+-- _ignore_sample_ and _accept_if_any_accepted_.
+These modes can be set by providing their names as command line arguments (through the "grader_flags" option in [testdata.yaml](#test-data-groups "wikilink")).
 If multiple conflicting modes are given, the last one is used. Their meaning are as follows.
 
 | Argument                 | Type         | Description                                                                                                                                                                                                                                                                                                    |


### PR DESCRIPTION
This removes 2 duplicate lines from the changelog and removes all trailing whitespace (and nothing else).