### PR TITLE
Add more languages to list of languages

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -60,27 +60,38 @@ If a single language from the table below can't be determined, building fails.
 
 For languages where there could be several entry points, the default entry point in the table below will be used.
 
-| Code       | Language    | Default entry point | File endings              |
-| ---------- | ----------- | ------------------- | ------------------------- |
-| c          | C           |                     | .c                        |
-| cpp        | C++         |                     | .cc, .cpp, .cxx, .c++, .C |
-| csharp     | C\#         |                     | .cs                       |
-| go         | Go          |                     | .go                       |
-| haskell    | Haskell     |                     | .hs                       |
-| java       | Java        | Main                | .java                     |
-| javascript | JavaScript  | main.js             | .js                       |
-| kotlin     | Kotlin      | MainKt              | .kt                       |
-| lisp       | Common Lisp | main.{lisp,cl}      | .lisp, .cl                |
-| objectivec | Objective-C |                     | .m                        |
-| ocaml      | OCaml       |                     | .ml                       |
-| pascal     | Pascal      |                     | .pas                      |
-| php        | PHP         | main.php            | .php                      |
-| prolog     | Prolog      |                     | .pl                       |
-| python2    | Python 2    | main.py2            | .py2                      |
-| python3    | Python 3    | main.py             | .py                       |
-| ruby       | Ruby        |                     | .rb                       |
-| rust       | Rust        |                     | .rs                       |
-| scala      | Scala       |                     | .scala                    |
+| Code        | Language     | Default entry point | File endings              |
+| ----------- | ------------ | ------------------- | ------------------------- |
+| apl         | APL          |                     | .apl                      |
+| bash        | Bash         |                     | .sh                       |
+| ada         | Ada          |                     | .adb, .ads                |
+| c           | C            |                     | .c                        |
+| cobol       | COBOL        |                     | .cob                      |
+| cpp         | C++          |                     | .cc, .cpp, .cxx, .c++, .C |
+| csharp      | C\#          |                     | .cs                       |
+| dart        | Dart         |                     | .dart                     |
+| fsharp      | F\#          |                     | .fs                       |
+| fortran     | Fortran      |                     | .f90                      |
+| gerbil      | Gerbil       |                     | .ss                       |
+| go          | Go           |                     | .go                       |
+| haskell     | Haskell      |                     | .hs                       |
+| java        | Java         | Main                | .java                     |
+| javascript  | JavaScript   | main.js             | .js                       |
+| julia       | Julia        |                     | .jl                       |
+| kotlin      | Kotlin       | MainKt              | .kt                       |
+| lisp        | Common Lisp  | main.{lisp,cl}      | .lisp, .cl                |
+| objectivec  | Objective-C  |                     | .m                        |
+| ocaml       | OCaml        |                     | .ml                       |
+| pascal      | Pascal       |                     | .pas                      |
+| php         | PHP          | main.php            | .php                      |
+| prolog      | Prolog       |                     | .pl                       |
+| python2     | Python 2     | main.py2            | .py2                      |
+| python3     | Python 3     | main.py             | .py                       |
+| ruby        | Ruby         |                     | .rb                       |
+| rust        | Rust         |                     | .rs                       |
+| scala       | Scala        |                     | .scala                    |
+| typescript  | TypeScript   |                     | .ts                       |
+| visualbasic | Visual Basic |                     | .vb                       |
 
 New in version `2023-07`: `.py` files now default to Python 3, and using shebangs are no longer supported;
 Python 2 has to be explicitly indicated by the `.py2` extension.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -62,27 +62,38 @@ language will be determined by looking at the shebang line which must match the 
 
 For languages where there could be several entry points, the default entry point in the table below will be used.
 
-| Code       | Language    | Default entry point | File endings              | Shebang                                                                                      |
-| ---------- | ----------- | ------------------- | ------------------------- | -------------------------------------------------------------------------------------------- |
-| c          | C           |                     | .c                        |                                                                                              |
-| cpp        | C++         |                     | .cc, .cpp, .cxx, .c++, .C |                                                                                              |
-| csharp     | C\#         |                     | .cs                       |                                                                                              |
-| go         | Go          |                     | .go                       |                                                                                              |
-| haskell    | Haskell     |                     | .hs                       |                                                                                              |
-| java       | Java        | Main                | .java                     |                                                                                              |
-| javascript | JavaScript  | main.js             | .js                       |                                                                                              |
-| kotlin     | Kotlin      | MainKt              | .kt                       |                                                                                              |
-| lisp       | Common Lisp | main.{lisp,cl}      | .lisp, .cl                |                                                                                              |
-| objectivec | Objective-C |                     | .m                        |                                                                                              |
-| ocaml      | OCaml       |                     | .ml                       |                                                                                              |
-| pascal     | Pascal      |                     | .pas                      |                                                                                              |
-| php        | PHP         | main.php            | .php                      |                                                                                              |
-| prolog     | Prolog      |                     | .pl                       |                                                                                              |
-| python2    | Python 2    | main.py             | .py                       | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
-| python3    | Python 3    | main.py             | .py                       | Matches the regex "`^#!.*python3`"                                                           |
-| ruby       | Ruby        |                     | .rb                       |                                                                                              |
-| rust       | Rust        |                     | .rs                       |                                                                                              |
-| scala      | Scala       |                     | .scala                    |                                                                                              |
+| Code        | Language     | Default entry point | File endings              | Shebang                                                                                      |
+| ----------- | ------------ | ------------------- | ------------------------- | -------------------------------------------------------------------------------------------- |
+| apl         | APL          |                     | .apl                      |                                                                                              |
+| bash        | Bash         |                     | .sh                       |                                                                                              |
+| ada         | Ada          |                     | .adb, .ads                |                                                                                              |
+| c           | C            |                     | .c                        |                                                                                              |
+| cobol       | COBOL        |                     | .cob                      |                                                                                              |
+| cpp         | C++          |                     | .cc, .cpp, .cxx, .c++, .C |                                                                                              |
+| csharp      | C\#          |                     | .cs                       |                                                                                              |
+| dart        | Dart         |                     | .dart                     |                                                                                              |
+| fsharp      | F\#          |                     | .fs                       |                                                                                              |
+| fortran     | Fortran      |                     | .f90                      |                                                                                              |
+| gerbil      | Gerbil       |                     | .ss                       |                                                                                              |
+| go          | Go           |                     | .go                       |                                                                                              |
+| haskell     | Haskell      |                     | .hs                       |                                                                                              |
+| java        | Java         | Main                | .java                     |                                                                                              |
+| javascript  | JavaScript   | main.js             | .js                       |                                                                                              |
+| julia       | Julia        |                     | .jl                       |                                                                                              |
+| kotlin      | Kotlin       | MainKt              | .kt                       |                                                                                              |
+| lisp        | Common Lisp  | main.{lisp,cl}      | .lisp, .cl                |                                                                                              |
+| objectivec  | Objective-C  |                     | .m                        |                                                                                              |
+| ocaml       | OCaml        |                     | .ml                       |                                                                                              |
+| pascal      | Pascal       |                     | .pas                      |                                                                                              |
+| php         | PHP          | main.php            | .php                      |                                                                                              |
+| prolog      | Prolog       |                     | .pl                       |                                                                                              |
+| python2     | Python 2     | main.py2            | .py2                      | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
+| python3     | Python 3     | main.py             | .py                       | Matches the regex "`^#!.*python3`"                                                           |
+| ruby        | Ruby         |                     | .rb                       |                                                                                              |
+| rust        | Rust         |                     | .rs                       |                                                                                              |
+| scala       | Scala        |                     | .scala                    |                                                                                              |
+| typescript  | TypeScript   |                     | .ts                       |                                                                                              |
+| visualbasic | Visual Basic |                     | .vb                       |                                                                                              |
 
 <div class="not-icpc">
 


### PR DESCRIPTION
Add any language that is either listed in the latest [CLICS Contest API standard](https://ccs-specs.icpc.io/2023-06/contest_api#languages) or [supported by Kattis](https://open.kattis.com/help).

Fixes #102 