### PR TITLE
Draft CUE schemas for 7505413

### DIFF
--- a/support/schemas/problem.cue
+++ b/support/schemas/problem.cue
@@ -1,0 +1,41 @@
+package problem_package
+
+#problem_settings: {
+	name!:                    string | close({[#language_code]: string})
+	problem_format_version?: *"legacy" | "draft" | =~"^[0-9]{4}-[0-9]{2}(-draft)?$"
+
+	author?:       #author_information | [...#author_information]
+	source?:       string
+	source_url?:   string // only allow if source exists
+	license?:      *"unknown" | "public domain" | #license_with_rights
+	rights_owner?: string
+	if rights_owner != _|_ {license?: #license_with_rights}
+
+	type?:       *"pass-fail" | "scoring"
+	validation?: *"default" | "custom" | close({["multipass" | "interactive" | "scoring"]: _})
+	limits?: {
+		time_multiplier?: {
+			ac_to_time_limit?:  *2.0 | number
+			time_limit_to_tle?: *1.5 | number
+		}
+		time_limit?:      number & >0
+		time_resolution?: *1.0 | number
+		[#other_limits]:  int
+	}
+	constants?: {[=~"^[a-z0-9]+$"]: number | string}
+	keywords?: string | [...string]
+	uuid?:     string
+	keywords?: string | [...string]
+	if validation.scoring != _|_ {type: "scoring"}
+	languages?: *"all" | [...string]
+}
+
+#problem_settings
+
+#author_information : string | {
+	name!: string
+	email?: string
+}
+#license_with_rights: "cc0" | "cc by" | "cc by-sa" | "educational" | "permission"
+#language_code:       =~"^[a-z]{2,4}(-[A-Z][A-Z])?$"
+#other_limits:        "memory" | "output" | "code" | "compilation_time" | "compilation_memory" | "validation_time" | "validation_memory" | "validation_output"

--- a/support/schemas/testdata.cue
+++ b/support/schemas/testdata.cue
@@ -1,0 +1,13 @@
+package problem_package
+
+#testdata_settings: {
+	input_validator_flags?:  *"" | string | {[string]: string}
+	output_validator_flags?: *"" | string
+        grading?: {
+		score?:       string
+		max_score?:   string
+		aggregation?: "sum" | "min"
+	}
+}
+
+#testdata_settings

--- a/support/schemas/testdata.cue
+++ b/support/schemas/testdata.cue
@@ -4,8 +4,8 @@ package problem_package
 	input_validator_flags?:  *"" | string | {[string]: string}
 	output_validator_flags?: *"" | string
         grading?: {
-		score?:       string
-		max_score?:   string
+		score?:       number
+		max_score?:   number
 		aggregation?: "sum" | "min"
 	}
 }


### PR DESCRIPTION
Here are two CUE schemas (for `problem.yaml` and `testdata.yaml`) that try to capture the state of the specification as of `2023-07-draft`,  21. Sep 2023, commit [7505413](https://github.com/Kattis/problem-package-format/commit/7505413f3e9d327e4f1f65e77950dbf6f012e64c).

I am quite happy with these, except for the following.

# 1. `problem_format_version`

Please seriously consider adopting semantic versioning, like `2.0.0-rc1` or `1.1-alpha`? We’re shooting ourselves in the foot with a home-made versioning tradition. It leads to confusion and frustration, and deliberately avoids lots of useful tools (in documentation and version control) that have been created to facility exactly our problem (namely communicating about versions)

# 2. `validation` 

This is a mess. Currently we have, at best,

```cue
validation?: *"default" | string
```
and a prose specification substrings of "custom, multipass, interactive, score” that is really hard to specify (much less provide editor support for.) Allowed is `validation: default` and `validation: score multipass interactive` but not `vaildation: interactive interactive default`.

I propose to actually use YAML for this, so we’d have 

```cue
validation?: *"default" |  close({
  multipass?: bool
  interactive?: bool
  score?: bool
})
```
so you write `validation: default` (or leave it out) or `validation: { interactive: True; score: True }`. Parsing is for free, specification is clear, editor support (including autocomplete) is out-of-the-box.

We can, as a compromise, do something like this:
```cue
  validation?: string
  _validation_ok: strings.Split(validation, " ") & (["default"] | ["custom", ...#validation_flags])
  _validation_flags: "interactive" | "score" | "multipass"
```

which would allow `default` and `custom` and `custom score interactive`, but not `default score` or `interactive` or `foo`. But this would still allow `custom score score score score` and disallow `interactive custom`. And it’s quite opaque, will give very little editor support, and feels like a bad use of strings for a use case that YAML exactly solves. 

The details of how (and if) to specify

```cue
if validation.score != _|_ {type: "scoring"}
```
(“scoring validators can only exist for scoring problems”) are downstream from this.

## 2.1

Do we really mean `score` instead of `scoring` here? That doesn’t fit, linguistically.

# 3. Grading

In `testdata.yaml`, we now have 

```yaml
grading?: {
  score?:       string
  max_score?:   string
  aggregation?: "sum" | "min"
```
I thought was called `scoring`? The phrase “grading“ makes little sense here to me, _grading_ is no longer a concept in the specification.

I think this should just be called `scoring` (the key has had that name earlier.)

# 4. Number types for `score`, `max_score`

See above, I think we mean

```yaml
score?:       number
max_score?:  number
```

I think it’s uncontroversial and have updated the PR with that change.