### PR TITLE
Invalid testcases (input and ouput validation)

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -422,18 +422,22 @@ The samples should still be validated by input and output validators.
 Note that the keys `input_validator_flags` and `output_validator_flags` in `testdata.yaml`, as described above,
 may be used to alter the behavior of the validators for the sample test data group.
 
-### Invalid Input Files
+### Invalid Test Cases
 
-In the `data/` directory, there may be an `invalid_inputs/` directory containing input files that must be rejected by at least one input validator.
-These are meant to only test the input validators, and are not used for judging.
-The rejected input files can be organized into a tree-like structure similar to the test data.
+The `data` directory may contain an `invalid` directory of test cases that must be rejected by validation.
+
+Invalid input
+: Unlike `sample` and `secret`, there does not have to be a `invalid-testcase.ans` file for every `invalid-testcase.in` in `invalid`. 
+Every such `.in`-file without a matching `.ans`-file must be _rejected_ by at least one input validator.
+
+Invalid output
+: If `invalid-testcase.ans` exists then `invalid-testcase.in` must exist and must _pass_ input validation.
+If `invalid-testcase.out` exists, then `invalid-testcase.ans` must exist, and the `.out`-file must be _rejected_ by the output validator. 
 
 <span class="not-icpc">
-
-By default, the `input_validator_flags` of the `data/testdata.yaml` apply to the invalid inputs as well.
-There may be additional `testdata.yaml` files (or symlinks) within the `data/invalid_inputs/` tree, but note that only the value of `input_validator_flags` will be used.
-
+The directory `invalid` can be organised into a tree-like structure similar to `secret`, and contain flags in `testdata.yaml` files that are passed to the validators.
 </span>
+
 
 <div class="not-icpc">
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -433,7 +433,8 @@ Unlike in `sample` and `secret`, there are no `.ans` files.
 Each `tc.in` under `invalid_input` must be rejected by at least one input validator.
 
 
-**Invalid output.**
+#### Invalid output
+
 The test cases in `invalid_output` describe invalid outputs for non-interactive problems.
 They consist of three files.
 The input file `tc.in` must _pass_ input validation. 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -424,15 +424,28 @@ may be used to alter the behavior of the validators for the sample test data gro
 
 ### Invalid Test Cases
 
-The `data` directory may contain an `invalid` directory of test cases that must be rejected by validation.
+The `data` directory may contain directories of test cases that must be rejected by validation.
+Their goal is to ensure integrity and quality of the test data and validation programs.
 
-Invalid input
-: Unlike `sample` and `secret`, there does not have to be a `invalid-testcase.ans` file for every `invalid-testcase.in` in `invalid`. 
-Every such `.in`-file without a matching `.ans`-file must be _rejected_ by at least one input validator.
+**Invalid input.** 
+The files under `invalid_input`  are invalid  inputs.
+Unlike in `sample` and `secret`, there are no `.ans` files.
+Each `tc.in` under `invalid_input` must be rejected by at least one input validator.
 
-Invalid output
-: If `invalid-testcase.ans` exists then `invalid-testcase.in` must exist and must _pass_ input validation.
-If `invalid-testcase.out` exists, then `invalid-testcase.ans` must exist, and the `.out`-file must be _rejected_ by the output validator. 
+
+**Invalid output.**
+The test cases in `invalid_output` describe invalid outputs for non-interactive problems.
+They consist of three files.
+The input file `tc.in` must _pass_ input validation. 
+The default answer file `tc.ans` must _pass_ output validation.
+The output file `tc.out` must _fail_ output validation.
+
+In particular, for an existing feedback directory `dir`, 
+```bash
+output_validator tc.in tc.ans dir [flags] < tc.ans # MUST PASS
+output_validator tc.in tc.ans dir [flags] < tc.out # MUST FAIL
+```
+
 
 <span class="not-icpc">
 The directory `invalid` can be organised into a tree-like structure similar to `secret`, and contain flags in `testdata.yaml` files that are passed to the validators.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -427,7 +427,8 @@ may be used to alter the behavior of the validators for the sample test data gro
 The `data` directory may contain directories of test cases that must be rejected by validation.
 Their goal is to ensure integrity and quality of the test data and validation programs.
 
-**Invalid input.** 
+#### Invalid input
+
 The files under `invalid_input`  are invalid  inputs.
 Unlike in `sample` and `secret`, there are no `.ans` files.
 Each `tc.in` under `invalid_input` must be rejected by at least one input validator.


### PR DESCRIPTION
(28 Jan: Directory structure changed.)

This section extends the scope of invalid _inputs_ to invalid _testcases_. It _retains_ the semantics of what a single test case input file `invalid_testcase.in` should mean (namely, that it should be rejected by at least one input validator). It _adds_ semantics for invalid outputs consistent with the rest of the specification.

The resulting body text is between the next two rules:

---
### Invalid Test Cases

The `data` directory may contain directories of test cases that must be rejected by validation.
Their goal is to ensure integrity and quality of the test data and validation programs.

**Invalid input.** 
The files under `invalid_input`  are invalid  inputs. Unlike in `sample` and `secret`, there are no `.ans` files. Each `tc.in` under `invalid_input` must be rejected by at least one input validator.


**Invalid output.**
The test cases in `invalid_output` describe invalid outputs for non-interactive problems. They consist of three files. The input file `tc.in` must _pass_ input validation. The default answer file `tc.ans` must _pass_ output validation. The output file `tc.out` must _fail_ output validation.

In particular, for an existing feedback directory `dir`, 
```bash
output_validator tc.in tc.ans dir [flags] < tc.ans # MUST PASS
output_validator tc.in tc.ans dir [flags] < tc.out # MUST FAIL
```


<span class="not-icpc">
The directory `invalid` can be organised into a tree-like structure similar to `secret`, and contain flags in `testdata.yaml` files that are passed to the validators.
</span>




---

You can have, say for [howl](https://open.kattis.com/problems/howl), specified in yaml just to be terse:
```yaml
invalid_input:
  hw_in:
    in: "AOHW"
  consec_w_in:
    in: "AHOWW"
invalid_output:
  echo:
    in: "AAHOOW"
    ans: "AWAWHOO"
    out: "AAHOOW"
  short:
    in: "AAHOOW"
    ans: "AWAWHOO"
    out: "AHOW"
```

This _solves_ #143 .

Related: #98, closed issue  #29