### PR TITLE
Clarify working directories for submissions and validators

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -41,6 +41,7 @@ All floating point numbers must be given as the external character sequences def
 There are a number of different kinds of programs that may be provided in the problem package: submissions, input validators, and output validators.
 All programs are always represented by a single file or directory.
 In other words, if a program consists of several files, these must be provided in a single directory.
+In the case that a program is a single file, it is treated as if a directory with the same name takes its place, which contains only that file.
 The name of the program, for the purpose of referring to it within the package is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
@@ -92,6 +93,11 @@ For languages where there could be several entry points, the default entry point
 | scala       | Scala        |                     | .scala                    |
 | typescript  | TypeScript   |                     | .ts                       |
 | visualbasic | Visual Basic |                     | .vb                       |
+
+The binary (and other artifacts that result from compiling the program) must be placed in the program's directory (or a copy of it).
+Each submission must be run with a working directory which contains (a copy of) the submitted files and any compiled binaries, but it must not contain any of the files described in the "Test data" section.
+Each input validator must be run with a working directory which contains the files in the program directory of the input validator in question.
+Each output validator must be run with a working directory which contains the submitted files and any compiled binaries of the submission being validated.
 
 <div class="not-icpc">
 

--- a/spec/changelog.md
+++ b/spec/changelog.md
@@ -32,6 +32,7 @@ sort: 1
 - Clarified when code limit is applied in the case of included code
 - Make `uuid` required in `problem.yaml`.
 - Add `/submissions/rejected` directory.
+- Clarify working directories for submissions and validators.
 
 ## Legacy version (changes since beginning 2021)
 


### PR DESCRIPTION
Closes #5

Working directory includes submission files for execution of submissions and output validators.
This allows both the submission and the output validator to easily access files which are submitted, or even created by the submission.
For example, perhaps the submission must write to a file some extra information which the output validator then verifies.
The output validator can then also access its own directory using the argv method discussed in the issue.
For input validators, there is no executing submission, so for convenience of writing the input validator, having the working directory as the validator's directory is nice.

I believe these changes cover all that was discussed.