### PR TITLE
Verdict for scoring problems

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -757,8 +757,34 @@ where test cases are run in lexicographical order of their full file paths (note
 
 <div class="not-icpc">
 
-For scoring problems, the concept of verdict is less important.
-In fact, some judging systems may choose to not even present a final verdict for a submission, but instead only present, for example, the score and the verdicts on the test cases the submission failed.
+In scoring problems, submissions are given a non-negative score. 
+The goal of the submission is the maximize the score.
+
+Given a submission, scores are determined for test cases, test groups, and the submission itself.
+
+The score of a failed test case is always 0. By default, the score of an accepted test case is 1. 
+If a custom output validator produces a score, then that value is used instead.
+
+The score of a test group is determined by its subgroups and test cases. 
+If it has no subgroups or test cases, then its score is 0.
+Otherwise, the score depends on the aggregation mode, which is either `min` or `sum`,
+The score of the group then results in the minimum or the sum of all the sub-scores, respectively.
+If using `min` aggregation, then the verdict must not be accepted if any sub-verdict is rejected.
+If using `sum` aggregation, then the verdict must be accepted if any sub-verdict is accepted.
+
+The score of the submission is its score on the topmost test group `data`.
+
+Ultimately, the score cannot be non-zero if the topmost verdict is not accepted. 
+Generally, an accepted verdict will be accompanied by a strictly positive score. 
+However, note that there can be a distinction between a non-accepted verdict and an accepted verdict with score 0.
+An accepted verdict with a score of 0 could mean that the output is well formed but not good enough to score points.
+
+For example, consider an optimization problem such as the Travelling Salesperson Problem.
+The goal is to provide the shortest possible route, and score is determined by how short of a route the submission outputs.
+If a submission instead outputs the longest possible route, it may get a verdict of accepted, because the output is well formed.
+However, the route is so long that by most metrics, the submission's score would be 0.
+In most cases, the output validator could simply check whether the score is 0 and reject instead of accepting for the test case,
+but this is a detail left to the author of the problem.
 
 The scoring behavior is configured by the following flags under `scoring` in `testdata.yaml`:
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -758,16 +758,16 @@ where test cases are run in lexicographical order of their full file paths (note
 <div class="not-icpc">
 
 In scoring problems, submissions are given a non-negative score. 
-The goal of the submission is the maximize the score.
+The goal of the submission is to maximize the score.
 
 Given a submission, scores are determined for test cases, test groups, and the submission itself.
 
 The score of a failed test case is always 0. By default, the score of an accepted test case is 1. 
-If a custom output validator produces a score, then that value is used instead.
+If a custom output validator produces a score or if a different `score` is set in `testdata.yaml` , then the product of those values is used instead.
 
 The score of a test group is determined by its subgroups and test cases. 
 If it has no subgroups or test cases, then its score is 0.
-Otherwise, the score depends on the aggregation mode, which is either `min` or `sum`,
+Otherwise, the score depends on the aggregation mode, which is either `min` or `sum`.
 The score of the group then results in the minimum or the sum of all the sub-scores, respectively.
 If using `min` aggregation, then the verdict must not be accepted if any sub-verdict is rejected.
 If using `sum` aggregation, then the verdict must be accepted if any sub-verdict is accepted.
@@ -783,7 +783,7 @@ For example, consider an optimization problem such as the Travelling Salesperson
 The goal is to provide the shortest possible route, and score is determined by how short of a route the submission outputs.
 If a submission instead outputs the longest possible route, it may get a verdict of accepted, because the output is well formed.
 However, the route is so long that by most metrics, the submission's score would be 0.
-In most cases, the output validator could simply check whether the score is 0 and reject instead of accepting for the test case,
+In most cases, an output validator should probably reject a test case rather than accepting and returning a score of 0,
 but this is a detail left to the author of the problem.
 
 The scoring behavior is configured by the following flags under `scoring` in `testdata.yaml`:


### PR DESCRIPTION
I based this on Thore's writeup which is linked in the issue.
Closes #110 

Verdict aggregation is no longer defined so I believe this is what we want after that change.
This means that the aggregation of the verdict is an implementation detail, whether it is first error or something else.
The only requirements are the ones stated based on whether score is aggregated using min or sum.