### PR TITLE
Reorder metadata subsections to match table

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -134,6 +134,13 @@ Any unknown keys should be treated as an error.
 | <span class="not-icpc">languages</span>  | <span class="not-icpc">String or sequence of strings</span> | <span class="not-icpc">all</span>                        | <span class="not-icpc">List of programming languages or the string `all`.</span>
 | constants                                | map of strings to int, float, or string                     |                                                          | Global constant values used by the problem. See definition below.
 
+### Name
+
+If there are statements in more than one language, the `name` field must be a map with the language codes as keys and the problem names as values.
+The set of languages for which `name` is given must **exactly** match the set of languages for which a problem statement exists.
+
+If only a single problem statement exists, this may be a string with the name of the problem in that language (but a map with a single key is allowed).
+
 ### Credits
 
 Allowed keys for credits.
@@ -198,13 +205,6 @@ credits:
     authors: Authy McAuth <authy@mcauth.example>
 ```
 to support a less verbose credits section.
-
-### Name
-
-If there are statements in more than one language, the `name` field must be a map with the language codes as keys and the problem names as values.
-The set of languages for which `name` is given must **exactly** match the set of languages for which a problem statement exists.
-
-If only a single problem statement exists, this may be a string with the name of the problem in that language (but a map with a single key is allowed).
 
 ### License
 


### PR DESCRIPTION
Moving "Name" before "Credits", since that's the order in the table.