### PR TITLE
Add solution descriptions in `solution/`

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -345,6 +345,20 @@ However, judging systems must make a best effort to correctly render **at minimu
 
 Public, i.e. non-secret, files to be made available in addition to the problem statement and sample test data are provided in the directory `attachments/`.
 
+## Solution description
+
+A description of how the problem is intended to be solved is provided in the directory `solution/`.
+
+This directory must contain one file per language, for at least one language, named `solution.`\<language\>`.`\<filetype\>.
+Language must be given as the shortest ISO 639 code.
+If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code.
+Optionally, the language code can be left out, the default is then English (`en`).
+The set of languages used can be different from what was used for the problem statement.
+Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PDF.
+
+Auxiliary files needed by the problem statement files must all be in `solution/`.
+`solution.<language>.<filetype>` should reference auxiliary files as if the working directory is `solution/`.
+
 ## Test data
 
 The test data are provided in subdirectories of `data/`.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -350,8 +350,7 @@ Public, i.e. non-secret, files to be made available in addition to the problem s
 A description of how the problem is intended to be solved is provided in the directory `solution/`.
 
 This directory must contain one file per language, for at least one language, named `solution.`\<language\>`.`\<filetype\>.
-Language must be given as the shortest ISO 639 code.
-If needed a hyphen and a ISO 3166-1 alpha-2 code may be appended to ISO 639 code.
+Language is given the same was as for problem statements.
 Optionally, the language code can be left out, the default is then English (`en`).
 The set of languages used can be different from what was used for the problem statement.
 Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PDF.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -350,7 +350,7 @@ Public, i.e. non-secret, files to be made available in addition to the problem s
 A description of how the problem is intended to be solved is provided in the directory `solution/`.
 
 This directory must contain one file per language, for at least one language, named `solution.`\<language\>`.`\<filetype\>.
-Language is given the same was as for problem statements.
+Language is given the same way as for problem statements.
 Optionally, the language code can be left out, the default is then English (`en`).
 The set of languages used can be different from what was used for the problem statement.
 Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PDF.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -358,6 +358,8 @@ Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PD
 Auxiliary files needed by the problem statement files must all be in `solution/`.
 `solution.<language>.<filetype>` should reference auxiliary files as if the working directory is `solution/`.
 
+Exactly how the solution description is used is up to the user or tooling.
+
 ## Test data
 
 The test data are provided in subdirectories of `data/`.


### PR DESCRIPTION
Closes #70 

If anything the solution files are somewhat underspecified. I think that's fine (for now), and it's definitely better than being overspecified.