### PR TITLE
Remove ICPC subset

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1,17 +1,12 @@
 ---
 layout: default
 title: 2023-07-draft (latest)
-show_diff_buttons: true
 sort: 2
 ---
 
 # Problem Package Format
 
 This is the `2023-07-draft` version of the Kattis problem package format.
-
-There are two variants of this specification: the Full version, and the ICPC subset.
-Use the buttons in the sidebar to select one of them.
-The unified view shows text that is not in the ICPC-subset in <span style="color:red">red</span>.
 
 ## Overview
 
@@ -110,7 +105,7 @@ Any unknown keys should be treated as an error.
 | Key                                      | Type                                                        | Default                                                  | Comments
 | ---------------------------------------  | ----------------------------------------------------------- | -------------------------------------------------------  | --------
 | problem_format_version                   | String                                                      | `legacy`                                                 | Version of the Problem Package Format used for this package. If using this version of the Format must be the string `2023-07-draft`. Will be on the form `<yyyy>-<mm>` for a stable version, `<yyyy>-<mm>-draft` or `draft` for a draft version, or `legacy` for the version before the addition of problem_format_version. Documentation for version `<version>` is available at https://www.kattis.com/problem-package-format/spec/problem_package_format/<version>.
-| <span class="not-icpc">type</span>       | <span class="not-icpc">String or sequence of strings</span> | <span class="not-icpc">`pass-fail`</span>                  | <span class="not-icpc">Type of problem. Values must be from the ones [defined below](#type).</span>
+| type                                     | String or sequence of strings                               | `pass-fail`                                              | Type of problem. Values must be from the ones [defined below](#type).
 | name                                     | String or map of strings                                    |                                                          | Required. The name of the problem in each of the languages for which a problem statement exists. See below for details.
 | uuid                                     | String                                                      |                                                          | Required. UUID identifying the problem.
 | credits                                  | String or map with keys as defined below.                   |                                                          | Who should get credits. See below for details.
@@ -120,7 +115,7 @@ Any unknown keys should be treated as an error.
 | rights_owner                             | String                                                      | Value of authors, if present, otherwise value of source. | Owner of the copyright of the problem. If not present, authors are the owners. If author is not present either, source is owner. Required if license is something other than `unknown` or `public domain`. Forbidden if license is `public domain`.
 | limits                                   | Map with keys as defined below                              | see definition below                                     |
 | keywords                                 | Sequence of strings                                         |                                                          | List of keywords.
-| <span class="not-icpc">languages</span>  | <span class="not-icpc">String or sequence of strings</span> | <span class="not-icpc">all</span>                        | <span class="not-icpc">List of programming languages or the string `all`.</span>
+| languages                                | String or sequence of strings                               | all                                                      | List of programming languages or the string `all`.
 | constants                                | map of strings to int, float, or string                     |                                                          | Global constant values used by the problem. See definition below.
 
 ### Type
@@ -267,15 +262,11 @@ Since time multipliers are more future-proof than absolute time limits, avoid sp
 Contest systems should make a best effort to respect the problem time limit,
 and should warn when importing a problem whose time limit is specified with precision greater than can be resolved by system timers.
 
-<div class="not-icpc">
-
 ### Languages
 
 A list of programming language codes from the table in the overview section or `all`.
 
 If a list is given, the problem may only be solved using those programming languages.
-
-</div>
 
 ### Constants
 
@@ -374,7 +365,7 @@ Judge systems may assume that the result of running a program on a test case is 
 For any two test cases, if the contents of their `.in` and `.args` files,
 and `.files` directory are equivalent, then the input of the two test cases is equivalent. 
 This means that for any two test cases, if their input,
-<div class="not-icpc"> output validator flags (see test data groups below)</div>
+output validator flags (see test data groups below)
 and the contents of their `.ans` files are equivalent, then the test cases are equivalent. 
 The assumption of determinism means that a judge system could choose to reuse the result of a previous run, or to re-run the equivalent test case.
 
@@ -425,28 +416,18 @@ If you want to provide files related to interactive problems (such as testing to
 
 ### Test Data Groups
 
-<div class="not-icpc">
-
 The test data for the problem can be organized into a tree-like structure.
 Each node of this tree is represented by a directory and referred to as a test data group.
 Each test data group may consist of zero or more test cases (i.e., input-answer files) and zero or more subgroups of test data (i.e., subdirectories).
 
-</div>
-
 At the top level, the test data is divided into exactly two groups: `sample` and `secret`.
-<span class="not-icpc">These two groups may be further split into subgroups as desired.</span>
-
-<div class="not-icpc">
+These two groups may be further split into subgroups as desired.
 
 The <em>result</em> of a test data group is computed by applying a <em>grader</em> to all of the sub-results (test cases and subgroups) in the group.
 See [Scoring](#scoring "wikilink") for more details.
 
-</div>
-
 Test cases and groups will be used in lexicographical order on file base name.
 If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
-
-<div class="not-icpc">
 
 In each test data group, a UTF-8 encoded YAML file `testdata.yaml` may be placed to specify how the result of the test data group should be computed.
 Some of the keys and their associated values will be inherited from the `testdata.yaml` in the closest ancestor group from the test case to the root `data` directory that has one.
@@ -461,8 +442,6 @@ The format of `testdata.yaml` is as follows:
 | input_validator_flags  | String or map of strings to strings | empty string            | Inherited      | Arguments passed to each input validator for this test data group. If a string then those are the flags that will be passed to each input validator for this test data group. If a map then each key is the name of the input validator and the value is the flags to pass to that input validator for this test data group. Validators not present in the map are run without flags.
 | output_validator_flags | String                              | empty string            | Inherited      | Arguments passed to the output validator for this test data group.
 | run_samples            | Boolean                             | true                    | Not applicable | Signifies whether samples should be run, see below for details.
-
-</div>
 
 ### Skipping Execution of Samples
 
@@ -509,13 +488,7 @@ output_validator tc.in tc.ans dir [flags] < tc.ans # MUST PASS
 output_validator tc.in tc.ans dir [flags] < tc.out # MUST FAIL
 ```
 
-
-<span class="not-icpc">
 The directory `invalid` can be organised into a tree-like structure similar to `secret`, and contain flags in `testdata.yaml` files that are passed to the validators.
-</span>
-
-
-<div class="not-icpc">
 
 ## Included Files
 
@@ -532,8 +505,6 @@ Language must be given as one of the language codes in the language table in the
 If any of the included files are supposed to be the main file (i.e. a driver),
 that file must have the language dependent name as given in the table referred above.
 
-</div>
-
 ## Example Submissions
 
 Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`.
@@ -542,7 +513,7 @@ The possible subdirectories are:
 | Value                                             | Requirement                                                                                                        | Comment
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------
 | accepted                                          | Accepted as a correct solution for all test cases.                                                                 | At least one is required.
-| <span class="not-icpc"> partially_accepted</span> | <span class="not-icpc"> Overall verdict must be Accepted. Overall score must be less than `max_score`.</span>      | <span class="not-icpc"> Must not be used for pass-fail problems.</span>
+| partially_accepted                                | Overall verdict must be Accepted. Overall score must be less than `max_score`.                                     | Must not be used for pass-fail problems.
 | rejected                                          | Is rejected (i.e. not accepted) for any reason in the final verdict.                                               |
 | wrong_answer                                      | Wrong answer for some test case. May be too slow or crash for other test cases.                                    |
 | time_limit_exceeded                               | Too slow relative to the safety margin for some test case. May output wrong answers or crash for other test cases. |
@@ -621,7 +592,7 @@ It must be provided as the directory `output_validator/`, and may contain `build
 It must adhere to the Output validator specification described below.
 If no custom validator is provided, the default output validator will be used.
 
-<span class="not-icpc">The output validator will be run on the output for every test data file using the arguments specified for the test data group.</span>
+The output validator will be run on the output for every test data file using the arguments specified for the test data group.
 
 ### Default Output Validator Specification
 
@@ -718,8 +689,6 @@ Having the judging system support other files is optional.
 Note that a validator may choose to ignore the feedback directory entirely.
 In particular, the judging system must not assume that the validator program creates any files there at all.
 
-<div class="not-icpc">
-
 #### Multi-pass validation
 
 A multi-pass validator can be used for problems that should run the submission multiple times sequentially,
@@ -735,8 +704,6 @@ It is a judge error to create the `nextpass.in` file and exit with any other cod
 
 All other files inside the feedback directory are guaranteed to persist between runs.
 In particular, the validator should only append text to the "judgemessage.txt" to provide combined feedback for all runs.
-
-</div>
 
 #### Examples
 
@@ -765,8 +732,6 @@ This information may be displayed to the user upon invocation of the validator.
 
 For pass-fail problems, the verdict of a submission is the first non-accepted verdict,
 where test cases are run in lexicographical order of their full file paths (note that `sample` comes before `secret` in this order).
-
-<div class="not-icpc">
 
 In scoring problems, submissions are given a non-negative score. 
 The goal of the submission is to maximize the score.
@@ -814,5 +779,3 @@ The defaults are as follows:
 
 They are chosen to minimize the configuration needed for a typical IOI-style problem, where points are given for passing all test cases in test data groups called subtasks.
 To achieve that behaviour, create groups `secret/subtask1`, `secret/subtask2`, ... and set the `score` value in the `secret/subtaskX/testdata.yaml`.
-
-</div>


### PR DESCRIPTION
Remove the markup of a "ICPC subset" from the new version of the standard. 

What was marked up was not really correct, in fact, there is not a clear consensus right now on what exactly is correct. Furthermore, especially after moving more information into type, it is now easier do describe subsets directly.