### PR TITLE
Escape {% %} for Liquid

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -281,7 +281,7 @@ If a list is given, the problem may only be solved using those programming langu
 
 A map of names to values. 
 Names must match the following regex: `[a-zA-Z0-9_.-]`. 
-*Constant sequences* are tokens (regex words) of the form `{%name%}`.
+*Constant sequences* are tokens (regex words) of the form {% raw %}`{%name%}`{% endraw %}.
 The `name` in every constant sequence must be a valid constant name.
 All constant sequences in the following files will be replaced by the value of the corresponding constant, formatted as described below:
   - problem statements


### PR DESCRIPTION
It turns out that the literal string `{%name%}` in the "Constants" section is interpreted by Liquid (used by Jekyll, used by GitHub pages) and crashes the GitHub pages build.

I added `{% raw%}` and `{% endraw %}` tags which should (?) fix this.

It's a little bit funny because we talked about the issue of`{%name%}` conflicting with something else. 

We do need to figure out how error handling should work, considering the possibility of conflicts. I.e. we say that we require that "The `name` in every constant sequence must be a valid constant name". What if there is a curly percentage tag for something unrelated in any one of our files. This would seemingly be an error, and we don't want that...