### PR TITLE
Multi-pass samples use .interaction format separated by ---

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -713,12 +713,18 @@ The time and memory limit apply for each invocation separately.
 
 To signal that the submission should be run again, the output validator must exit with code 42 and output the new input in the file `nextpass.in` in the feedback directory.
 Judging stops if no `nextpass.in` was created, or the output validator exited with any other code.
-Note that the `nextpass.in` will be removed before the next run.
+Note that the `nextpass.in` will be removed before the next pass.
 
 It is a judge error to create the `nextpass.in` file and exit with any other code than 42.
 
-All other files inside the feedback directory are guaranteed to persist between runs.
-In particular, the validator should only append text to the "judgemessage.txt" to provide combined feedback for all runs.
+All other files inside the feedback directory are guaranteed to persist between passes.
+In particular, the validator should only append text to the "judgemessage.txt" to provide combined feedback for all passes.
+
+Samples for multi-pass problems must be provided in a `.interaction` file,
+like for interactive problems. Passes are separated by a line containing `---` (three dashes).
+When the problem is not interactive, simply start each pass by a number of lines starting
+with `<`, containing the sample input, followed by some lines starting with `>`,
+containing the sample answer.
 
 #### Examples
 


### PR DESCRIPTION
Also we should use consistent terminology. It's called `multi-pass` so I'm using `pass` consistently now, but personally I'd prefer `round`.
- `pass`
- `run`
- `round`

Fix #177 