### PR TITLE
Change constants from {%x%} to {{x}}; allow unrecognised names

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -272,8 +272,10 @@ If a list is given, the problem may only be solved using those programming langu
 
 A map of names to values. 
 Names must match the following regex: `[a-zA-Z0-9_.-]`. 
-*Constant sequences* are tokens (regex words) of the form {% raw %}`{%name%}`{% endraw %}.
-The `name` in every constant sequence must be a valid constant name.
+*Constant sequences* are tokens (regex words) of the form `{{name}}`,
+where `name` is one of the names defined in `constants`.
+Tags `{{xyz}}` containing a name that is not defined are not modified, but may be warned for.
+
 All constant sequences in the following files will be replaced by the value of the corresponding constant, formatted as described below:
   - problem statements
   - input and output validators


### PR DESCRIPTION
Fix #176 