### PR TITLE
Specify LF line endings among general requirements

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -26,6 +26,8 @@ used for distributing and sharing problems for algorithmic programming contests 
   consist solely of lower or upper case letters a–z, A–Z, digits 0–9, period, dash, or underscore,
   but must not begin or end with period, dash, or underscore.
 * All text files for a problem must be UTF-8 encoded and not have a byte-order mark (BOM).
+* All text files must have Unix-style line endings (newline/LF byte only).
+  Note that LF is line-ending and not line-separating in POSIX, which means that all non-empty text files must end with a newline.
 * All floating-point numbers must be given as the external character sequences defined by IEEE 754-2008 and may use up to double precision.
 
 ### Programs

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -15,21 +15,18 @@ used for distributing and sharing problems for algorithmic programming contests 
 
 ### General Requirements
 
-The package consists of a single directory containing files as described below.
-The name of the directory must consist solely of lower case letters a-z and digits 0-9.
-Alternatively it can be a ZIP compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
-
-All file names for files included in the package must match the following regexp:
-
-`[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]`
-
-I.e., it must be of length at least 2,
-consist solely of lower or upper case letters a-z, A-Z, digits 0-9, period, dash or underscore,
-but must not begin or end with period, dash or underscore.
-
-All text files for a problem must be UTF-8 encoded and not have a byte order mark.
-
-All floating point numbers must be given as the external character sequences defined by IEEE 754-2008 and may use up to double precision.
+* The package must consist of a single directory containing files as described below.
+  The directory name must consist solely of lower case letters a–z and digits 0–9.
+  Alternatively, the package can be a ZIP-compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
+* All file names for files included in the package must match the regexp
+  ```regex
+  [a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]
+  ```
+  i.e., they must be of length at least 2,
+  consist solely of lower or upper case letters a–z, A–Z, digits 0–9, period, dash, or underscore,
+  but must not begin or end with period, dash, or underscore.
+* All text files for a problem must be UTF-8 encoded and not have a byte-order mark (BOM).
+* All floating-point numbers must be given as the external character sequences defined by IEEE 754-2008 and may use up to double precision.
 
 ### Programs
 


### PR DESCRIPTION
This PR makes several minor fix-ups to the General Requirements section, and adds a bullet point about Unix-style line endings.