### PR TITLE
Remove duplicate UTF-8 requirements

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -67,7 +67,7 @@ Each output validator must be run with a working directory which contains the su
 
 ## Problem Metadata
 
-Metadata about the problem (e.g., source, license, limits) are provided in a UTF-8 encoded YAML file named `problem.yaml` placed in the root directory of the package.
+Metadata about the problem (e.g., source, license, limits) are provided in a YAML file named `problem.yaml` placed in the root directory of the package.
 
 The keys are defined as below.
 Keys are optional unless explicitly stated.
@@ -477,7 +477,7 @@ See [Scoring](#scoring "wikilink") for more details.
 Test cases and groups will be used in lexicographical order on file base name.
 If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
 
-In each test data group, a UTF-8 encoded YAML file `testdata.yaml` may be placed to specify how the result of the test data group should be computed.
+In each test data group, a YAML file `testdata.yaml` may be placed to specify how the result of the test data group should be computed.
 Some of the keys and their associated values will be inherited from the `testdata.yaml` in the closest ancestor group from the test case to the root `data` directory that has one.
 Others need to be explicitly defined in the group's `testdata.yaml` file, otherwise they are set to the default values.
 If there is no `testdata.yaml` file in the root `data` group, one is implicitly added with the default values.
@@ -570,7 +570,7 @@ The possible subdirectories are:
 Every file or directory in these directories represents a separate solution.
 It is mandatory to provide at least one accepted solution.
 
-Metadata about the example submissions are provided in a UTF-8 encoded YAML file named `submissions.yaml` placed directly in the `submissions/` directory.
+Metadata about the example submissions are provided in a YAML file named `submissions.yaml` placed directly in the `submissions/` directory.
 The top level keys in `submissions.yaml` are globs matching example submissions.
 For example, `accepted/*` would match any submission in the `submissions/accepted/` directory.
 


### PR DESCRIPTION
All text files must be UTF-8, so we don't have to repeat this for every YAML file.