### PR TITLE
Add hyperlinks to VIVA and Checktestdata resources

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -585,7 +585,9 @@ Each glob maps to a map with keys as defined below specifying metadata for all s
 ## Input Validators
 
 Input Validators, for verifying the correctness of the input files, are provided in `input_validators/`.
-Input validators can be specified as VIVA-files (with file ending `.viva`), Checktestdata-file (with file ending `.ctd`), or as a program.
+Input validators can be specified as [VIVA](http://viva.vanb.org/)-files (with file ending `.viva`),
+[Checktestdata](https://github.com/DOMjudge/checktestdata)-file (with file ending `.ctd`),
+or as a program.
 Programs must either be written in C++ or Python 3, 
 or must provide a `build` or `run` script as specified [above](#programs).
 


### PR DESCRIPTION
VIVA and Checktestdata are not referenced or described anywhere else in the specification draft. This PR adds links so that the reader can find descriptions of the formats.

EDIT: Would it have been better to link to DOMjudge's page? https://www.domjudge.org/checktestdata