### PR TITLE
Clarify the requirements on sampe data in problem statements

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -321,7 +321,7 @@ Constant sequences are **not** replaced in test data files or in `problem.yaml` 
 The problem statement of the problem is provided in the directory `problem_statement/`.
 
 This directory must contain one file per language, for at least one language, named `problem.<language>.<filetype>`,
-that contains the problem text itself, including input and output specifications, but not sample input and output.
+that contains the problem text itself, including input and output specifications.
 Language must be given as the shortest ISO 639 code.
 If needed, a hyphen and an ISO 3166-1 alpha-2 code may be appended to an ISO 639 code.
 Optionally, the language code can be left out; the default is then English (`en`).
@@ -335,9 +335,10 @@ Auxiliary files needed by the problem statement files must all be in `problem_st
 `problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `problem_statement/`.
 Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-For problem statements provided in LaTeX or Markdown, the problem statements must only contain the actual problem statement and no sample data.
-It is the judge system's responsibility to append the sample data.
-For problem statement PDFs, the problem statement is displayed unmodified and must include this information.
+### Sample Data
+
+- For problem statements provided in LaTeX or Markdown: the statement file must contain only the problem description and input/output specifications and no sample data. It is the judge system's responsibility to append the sample data.
+- For problem statements provided as PDFs: the judge system will dispay the PDF verbatim, and therefore any sample data must be included in the PDF. The judge system is not required to reconcile sample data embedded in PDFs with the `sample` test data group nor to validate it in any other way.
 
 ### LaTeX Environment and Supported Subset
 


### PR DESCRIPTION
I've tried to make it clearer that sample data should be included iff the problem statement is in PDF format, and that the judge system bears no responsibility for any data embedded in the PDF.