### PR TITLE
Test case explanation

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -337,8 +337,10 @@ Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
 ### Sample Data
 
-- For problem statements provided in LaTeX or Markdown: the statement file must contain only the problem description and input/output specifications and no sample data. It is the judge system's responsibility to append the sample data.
-- For problem statements provided as PDFs: the judge system will display the PDF verbatim, and therefore any sample data must be included in the PDF. The judge system is not required to reconcile sample data embedded in PDFs with the `sample` test data group nor to validate it in any other way.
+- For problem statements provided in LaTeX or Markdown: the statement file must contain only the problem description and input/output specifications and no sample data. 
+  It is the judge system's responsibility to append the sample data.
+- For problem statements provided as PDFs: the judge system will display the PDF verbatim, and therefore any sample data must be included in the PDF. 
+  The judge system is not required to reconcile sample data embedded in PDFs with the `sample` test data group nor to validate it in any other way.
 
 ### LaTeX Environment and Supported Subset
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -355,6 +355,10 @@ It shall also provide the following commands:
   `width` is a floating-point argument specifying the width of the figure, as a fraction of the total width of the problem statement;
   `filename` is the image to display, and `caption`, the text to include below the figure.
   The illustration should be flushed right with text flowing around it (as in a `wrapfigure`).
+- `\nextsample`, tells the judge system to include the next sample test case here.
+  It is an error to use `\nextsample` when there are no remaining sample test cases.
+- `\remainingsamples`, tells the judge system to include all sample test cases that have not previously been included by `\nextsample`.
+  It is allowed to use `\remainingsamples` even if there are no remaining sample test cases, that will simply include nothing.
 
 Arbitrary LaTeX is not guaranteed to render correctly by HTML-based judging systems.
 However, judging systems must make a best effort to correctly render **at minimum** the following LaTeX subset when displaying a LaTeX problem statement:


### PR DESCRIPTION
Fixes #81 

Adds `\nextsample` and `\remainingsamples` to the LaTeX environment.

We need to decide on a method to do the same for Markdown.