### PR TITLE
Fix inconsistent markdown in spec document

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -851,13 +851,13 @@ The scoring behavior is configured by the following flags under `scoring` in `te
 | ------------- | -------------- | -----------
 | `score`       | String         | The score assigned to an accepted input file in the group. If a scoring output validator is used, this score is **multiplied** by the score from the validator.
 | `max_score`   | String         | A number specifying the maximum score allowed for this test group. It is an error to exceed this.
-| `aggregation` | `sum` or `min` | If sum, the score is the sum of the subresult scores. If min, the score is the minimum of the subresult scores.
+| `aggregation` | `sum` or `min` | If `sum`, the score is the sum of the subresult scores. If `min`, the score is the minimum of the subresult scores.
 
 The defaults are as follows:
 
-- The _data_ and _secret_ group: `score` is 1, `aggregation` is sum.
+- The _data_ and _secret_ group: `score` is 1, `aggregation` is `sum`.
 - The _sample_ group: `score` is 0, `aggregation` is `sum`.
-- Other groups: `score` is `1`, `aggregation` is `min`.
+- Other groups: `score` is 1, `aggregation` is `min`.
 - `max_score` is the sum of the `max_score` of the subresults if `scoring` is `sum`, and the minimum of the `max_score` of the subresults if `scoring` is `min`. For individual testcases, the `max_score` here means the `score` value of the group it is in.
 
 They are chosen to minimize the configuration needed for a typical IOI-style problem, where points are given for passing all test cases in test data groups called subtasks.


### PR DESCRIPTION
Fixes some formatting inconsistencies in the spec document.