### PR TITLE
Move specification of (natural) language codes to top

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -29,6 +29,8 @@ used for distributing and sharing problems for algorithmic programming contests 
 * All text files must have Unix-style line endings (newline/LF byte only).
   Note that LF is line-ending and not line-separating in POSIX, which means that all non-empty text files must end with a newline.
 * All floating-point numbers must be given as the external character sequences defined by IEEE 754-2008 and may use up to double precision.
+* Natural language keys (for example in the `name` map in ) must be given as 2-letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code if it exists, otherwise as a 3-letter code from ISO 639.
+  Optionally, it may be suffixed with a hyphen and an ISO 3166-1 alpha-2 code, for example `pt-br` to indicate Brazilian Portuguese.
 
 ### Programs
 
@@ -107,7 +109,21 @@ Two values that are listed as incompatible must not both be in the sequence.
 If there are statements in more than one language, the `name` field must be a map with the language codes as keys and the problem names as values.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a problem statement exists.
 
+A deliberately complex and construed example:
+```yaml
+name:
+  en: Hello World!
+  pt-br: Olá mundo!
+  pt-pt: Oi mundo!
+  fil: Kumusta mundo!
+```
+
 If only a single problem statement exists, this may be a string with the name of the problem in that language (but a map with a single key is allowed).
+
+So the following example implies that only an English language problem statement exists:
+```yaml
+name: Hello World!
+```
 
 ### Credits
 
@@ -120,7 +136,7 @@ A person is specified as either a string with their full name (optionally with a
 | authors           | Person or sequence of persons          |         | The people who conceptualized the problem.
 | contributors      | Person or sequence of persons          |         | The people who developed the problem package, such as statement, validators, and test data.
 | testers           | Person or sequence of persons          |         | The people who tested the problem package, for example by providing a solution and reviewing the statement.
-| translators       | Map of strings to sequences of persons |         | The people who translated the statement to other languages. Each key must be an ISO 639 language code.
+| translators       | Map of strings to sequences of persons |         | The people who translated the statement to other languages. Each key must be a language code as described in [General Requirements](#General Requirements "wikilink").
 | acknowledgements  | Person or sequence of persons          |         | Extra acknowledgements or special thanks that do not fit the other categories.
 
 The examples
@@ -331,8 +347,7 @@ The problem statement of the problem is provided in the directory `problem_state
 
 This directory must contain one file per language, for at least one language, named `problem.<language>.<filetype>`,
 that contains the problem text itself, including input and output specifications.
-Language must be given as the shortest ISO 639 code.
-If needed, a hyphen and an ISO 3166-1 alpha-2 code may be appended to an ISO 639 code.
+Here `<language>` is a language code as described in [General Requirements](#General Requirements "wikilink").
 Optionally, the language code can be left out; the default is then English (`en`).
 Filetype can be either `tex` for LaTeX files, `md` for Markdown, or `pdf` for PDF.
 


### PR DESCRIPTION
Refer to that from the text and also add some examples of languages codes in the description of the `name` key.