### PR TITLE
Move the languages table into a separate section in legacy specs

### DIFF
--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -51,66 +51,12 @@ If at least one of these two files is included:
    and will be invoked in the same way as a single file program.
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
-Language is determined by looking at the file endings.
+Language is determined by looking at the file endings as specified in the [languages table](#languages).
 If a single language from the table below can't be determined, building fails.
 In the case of Python 2 and 3 which share the same file ending,
-language will be determined by looking at the shebang line which must match the regular expressions in the table below.
+language will be determined by looking at the shebang line which must match the regular expressions in the [languages table](#languages).
 
-For languages where there could be several entry points, the default entry point in the table below will be used.
-
-| Code         | Language            | Default entry point | File endings                    | Shebang                                                                                      |
-| ------------ | ------------------- | ------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| ada          | Ada                 |                     | .adb, .ads                      |                                                                                              |
-| algol68      | Algol 68            |                     | .a68                            |                                                                                              |
-| apl          | APL                 |                     | .apl                            |                                                                                              |
-| bash         | Bash                |                     | .sh                             |                                                                                              |
-| c            | C                   |                     | .c                              |                                                                                              |
-| cgmp         | C with GMP          |                     | (.c)                            |                                                                                              |
-| cobol        | COBOL               |                     | .cob                            |                                                                                              |
-| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |                                                                                              |
-| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |                                                                                              |
-| crystal      | Crystal             |                     | .cr                             |                                                                                              |
-| csharp       | C\#                 |                     | .cs                             |                                                                                              |
-| d            | D                   |                     | .d                              |                                                                                              |
-| dart         | Dart                |                     | .dart                           |                                                                                              |
-| elixir       | Elixir              |                     | .ex                             |                                                                                              |
-| erlang       | Erlang              |                     | .erl                            |                                                                                              |
-| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |                                                                                              |
-| fortran      | Fortran             |                     | .f90                            |                                                                                              |
-| fsharp       | F\#                 |                     | .fs                             |                                                                                              |
-| gerbil       | Gerbil              |                     | .ss                             |                                                                                              |
-| go           | Go                  |                     | .go                             |                                                                                              |
-| haskell      | Haskell             |                     | .hs                             |                                                                                              |
-| java         | Java                | Main                | .java                           |                                                                                              |
-| javascript   | JavaScript          | main.js             | .js                             |                                                                                              |
-| julia        | Julia               |                     | .jl                             |                                                                                              |
-| kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |
-| lisp         | Common Lisp         | main.{lisp,cl}      | .lisp, .cl                      |                                                                                              |
-| lua          | Lua                 |                     | .lua                            |                                                                                              |
-| modula2      | Modula-2            |                     | .mod, .def                      |                                                                                              |
-| nim          | Nim                 |                     | .nim                            |                                                                                              |
-| objectivec   | Objective-C         |                     | .m                              |                                                                                              |
-| ocaml        | OCaml               |                     | .ml                             |                                                                                              |
-| octave       | Octave              |                     | (.m)                            |                                                                                              |
-| odin         | Odin                |                     | .odin                           |                                                                                              |
-| pascal       | Pascal              |                     | .pas                            |                                                                                              |
-| perl         | Perl                |                     | .pm, (.pl)                      |                                                                                              |
-| php          | PHP                 | main.php            | .php                            |                                                                                              |
-| prolog       | Prolog              |                     | .pl                             |                                                                                              |
-| python2      | Python 2            | main.py2            | (.py), .py2                     | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
-| python3      | Python 3            | main.py             | .py, .py3                       | Matches the regex "`^#!.*python3`"                                                           |
-| python3numpy | Python 3 with NumPy | main.py             | (.py, .py3)                     |                                                                                              |
-| racket       | Racket              |                     | .rkt                            |                                                                                              |
-| ruby         | Ruby                |                     | .rb                             |                                                                                              |
-| rust         | Rust                |                     | .rs                             |                                                                                              |
-| scala        | Scala               |                     | .scala                          |                                                                                              |
-| simula       | Simula              |                     | .sim                            |                                                                                              |
-| smalltalk    | Smalltalk           |                     | .st                             |                                                                                              |
-| snobol       | Snobol              |                     | .sno                            |                                                                                              |
-| swift        | Swift               |                     | .swift                          |                                                                                              |
-| typescript   | TypeScript          |                     | .ts                             |                                                                                              |
-| visualbasic  | Visual Basic        |                     | .vb                             |                                                                                              |
-| zig          | Zig                 |                     | .zig                            |                                                                                              |
+For languages where there could be several entry points, the default entry point in the [languages table](#languages) will be used.
 
 ## Problem Metadata
 
@@ -170,6 +116,62 @@ A map with the following keys:
 For most keys the system default will be used if nothing is specified.
 This can vary, but you SHOULD assume that it's reasonable.
 Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
+
+## Languages
+
+| Code         | Language            | Default entry point | File endings                    | Shebang                                                                                      |
+| ------------ | ------------------- | ------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
+| ada          | Ada                 |                     | .adb, .ads                      |                                                                                              |
+| algol68      | Algol 68            |                     | .a68                            |                                                                                              |
+| apl          | APL                 |                     | .apl                            |                                                                                              |
+| bash         | Bash                |                     | .sh                             |                                                                                              |
+| c            | C                   |                     | .c                              |                                                                                              |
+| cgmp         | C with GMP          |                     | (.c)                            |                                                                                              |
+| cobol        | COBOL               |                     | .cob                            |                                                                                              |
+| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |                                                                                              |
+| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |                                                                                              |
+| crystal      | Crystal             |                     | .cr                             |                                                                                              |
+| csharp       | C\#                 |                     | .cs                             |                                                                                              |
+| d            | D                   |                     | .d                              |                                                                                              |
+| dart         | Dart                |                     | .dart                           |                                                                                              |
+| elixir       | Elixir              |                     | .ex                             |                                                                                              |
+| erlang       | Erlang              |                     | .erl                            |                                                                                              |
+| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |                                                                                              |
+| fortran      | Fortran             |                     | .f90                            |                                                                                              |
+| fsharp       | F\#                 |                     | .fs                             |                                                                                              |
+| gerbil       | Gerbil              |                     | .ss                             |                                                                                              |
+| go           | Go                  |                     | .go                             |                                                                                              |
+| haskell      | Haskell             |                     | .hs                             |                                                                                              |
+| java         | Java                | Main                | .java                           |                                                                                              |
+| javascript   | JavaScript          | main.js             | .js                             |                                                                                              |
+| julia        | Julia               |                     | .jl                             |                                                                                              |
+| kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |
+| lisp         | Common Lisp         | main.{lisp,cl}      | .lisp, .cl                      |                                                                                              |
+| lua          | Lua                 |                     | .lua                            |                                                                                              |
+| modula2      | Modula-2            |                     | .mod, .def                      |                                                                                              |
+| nim          | Nim                 |                     | .nim                            |                                                                                              |
+| objectivec   | Objective-C         |                     | .m                              |                                                                                              |
+| ocaml        | OCaml               |                     | .ml                             |                                                                                              |
+| octave       | Octave              |                     | (.m)                            |                                                                                              |
+| odin         | Odin                |                     | .odin                           |                                                                                              |
+| pascal       | Pascal              |                     | .pas                            |                                                                                              |
+| perl         | Perl                |                     | .pm, (.pl)                      |                                                                                              |
+| php          | PHP                 | main.php            | .php                            |                                                                                              |
+| prolog       | Prolog              |                     | .pl                             |                                                                                              |
+| python2      | Python 2            | main.py2            | (.py), .py2                     | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
+| python3      | Python 3            | main.py             | .py, .py3                       | Matches the regex "`^#!.*python3`"                                                           |
+| python3numpy | Python 3 with NumPy | main.py             | (.py, .py3)                     |                                                                                              |
+| racket       | Racket              |                     | .rkt                            |                                                                                              |
+| ruby         | Ruby                |                     | .rb                             |                                                                                              |
+| rust         | Rust                |                     | .rs                             |                                                                                              |
+| scala        | Scala               |                     | .scala                          |                                                                                              |
+| simula       | Simula              |                     | .sim                            |                                                                                              |
+| smalltalk    | Smalltalk           |                     | .st                             |                                                                                              |
+| snobol       | Snobol              |                     | .sno                            |                                                                                              |
+| swift        | Swift               |                     | .swift                          |                                                                                              |
+| typescript   | TypeScript          |                     | .ts                             |                                                                                              |
+| visualbasic  | Visual Basic        |                     | .vb                             |                                                                                              |
+| zig          | Zig                 |                     | .zig                            |                                                                                              |
 
 ## Problem Statements
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -50,66 +50,12 @@ If at least one of these two files is included:
    and will be invoked in the same way as a single file program.
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
-Language is determined by looking at the file endings.
+Language is determined by looking at the file endings as specified in the [languages table](#languages).
 If a single language from the table below can't be determined, building fails.
 In the case of Python 2 and 3 which share the same file ending,
-language will be determined by looking at the shebang line which must match the regular expressions in the table below.
+language will be determined by looking at the shebang line which must match the regular expressions in the [languages table](#languages).
 
-For languages where there could be several entry points, the default entry point in the table below will be used.
-
-| Code         | Language            | Default entry point | File endings                    | Shebang                                                                                      |
-| ------------ | ------------------- | ------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| ada          | Ada                 |                     | .adb, .ads                      |                                                                                              |
-| algol68      | Algol 68            |                     | .a68                            |                                                                                              |
-| apl          | APL                 |                     | .apl                            |                                                                                              |
-| bash         | Bash                |                     | .sh                             |                                                                                              |
-| c            | C                   |                     | .c                              |                                                                                              |
-| cgmp         | C with GMP          |                     | (.c)                            |                                                                                              |
-| cobol        | COBOL               |                     | .cob                            |                                                                                              |
-| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |                                                                                              |
-| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |                                                                                              |
-| crystal      | Crystal             |                     | .cr                             |                                                                                              |
-| csharp       | C\#                 |                     | .cs                             |                                                                                              |
-| d            | D                   |                     | .d                              |                                                                                              |
-| dart         | Dart                |                     | .dart                           |                                                                                              |
-| elixir       | Elixir              |                     | .ex                             |                                                                                              |
-| erlang       | Erlang              |                     | .erl                            |                                                                                              |
-| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |                                                                                              |
-| fortran      | Fortran             |                     | .f90                            |                                                                                              |
-| fsharp       | F\#                 |                     | .fs                             |                                                                                              |
-| gerbil       | Gerbil              |                     | .ss                             |                                                                                              |
-| go           | Go                  |                     | .go                             |                                                                                              |
-| haskell      | Haskell             |                     | .hs                             |                                                                                              |
-| java         | Java                | Main                | .java                           |                                                                                              |
-| javascript   | JavaScript          | main.js             | .js                             |                                                                                              |
-| julia        | Julia               |                     | .jl                             |                                                                                              |
-| kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |
-| lisp         | Common Lisp         | main.{lisp,cl}      | .lisp, .cl                      |                                                                                              |
-| lua          | Lua                 |                     | .lua                            |                                                                                              |
-| modula2      | Modula-2            |                     | .mod, .def                      |                                                                                              |
-| nim          | Nim                 |                     | .nim                            |                                                                                              |
-| objectivec   | Objective-C         |                     | .m                              |                                                                                              |
-| ocaml        | OCaml               |                     | .ml                             |                                                                                              |
-| octave       | Octave              |                     | (.m)                            |                                                                                              |
-| odin         | Odin                |                     | .odin                           |                                                                                              |
-| pascal       | Pascal              |                     | .pas                            |                                                                                              |
-| perl         | Perl                |                     | .pm, (.pl)                      |                                                                                              |
-| php          | PHP                 | main.php            | .php                            |                                                                                              |
-| prolog       | Prolog              |                     | .pl                             |                                                                                              |
-| python2      | Python 2            | main.py2            | (.py), .py2                     | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
-| python3      | Python 3            | main.py             | .py, .py3                       | Matches the regex "`^#!.*python3`"                                                           |
-| python3numpy | Python 3 with NumPy | main.py             | (.py, .py3)                     |                                                                                              |
-| racket       | Racket              |                     | .rkt                            |                                                                                              |
-| ruby         | Ruby                |                     | .rb                             |                                                                                              |
-| rust         | Rust                |                     | .rs                             |                                                                                              |
-| scala        | Scala               |                     | .scala                          |                                                                                              |
-| simula       | Simula              |                     | .sim                            |                                                                                              |
-| smalltalk    | Smalltalk           |                     | .st                             |                                                                                              |
-| snobol       | Snobol              |                     | .sno                            |                                                                                              |
-| swift        | Swift               |                     | .swift                          |                                                                                              |
-| typescript   | TypeScript          |                     | .ts                             |                                                                                              |
-| visualbasic  | Visual Basic        |                     | .vb                             |                                                                                              |
-| zig          | Zig                 |                     | .zig                            |                                                                                              |
+For languages where there could be several entry points, the default entry point in the [languages table](#languages) will be used.
 
 ### Problem Types
 
@@ -186,6 +132,62 @@ A map with the following keys:
 | --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
 | objective             | String  | max     | One of "min" or "max" specifying whether it is a minimization or a maximization problem. |
 | show_test_data_groups | boolean | false   | Specifies whether test group results should be shown to the end user.                    |
+
+## Languages
+
+| Code         | Language            | Default entry point | File endings                    | Shebang                                                                                      |
+| ------------ | ------------------- | ------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
+| ada          | Ada                 |                     | .adb, .ads                      |                                                                                              |
+| algol68      | Algol 68            |                     | .a68                            |                                                                                              |
+| apl          | APL                 |                     | .apl                            |                                                                                              |
+| bash         | Bash                |                     | .sh                             |                                                                                              |
+| c            | C                   |                     | .c                              |                                                                                              |
+| cgmp         | C with GMP          |                     | (.c)                            |                                                                                              |
+| cobol        | COBOL               |                     | .cob                            |                                                                                              |
+| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |                                                                                              |
+| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |                                                                                              |
+| crystal      | Crystal             |                     | .cr                             |                                                                                              |
+| csharp       | C\#                 |                     | .cs                             |                                                                                              |
+| d            | D                   |                     | .d                              |                                                                                              |
+| dart         | Dart                |                     | .dart                           |                                                                                              |
+| elixir       | Elixir              |                     | .ex                             |                                                                                              |
+| erlang       | Erlang              |                     | .erl                            |                                                                                              |
+| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |                                                                                              |
+| fortran      | Fortran             |                     | .f90                            |                                                                                              |
+| fsharp       | F\#                 |                     | .fs                             |                                                                                              |
+| gerbil       | Gerbil              |                     | .ss                             |                                                                                              |
+| go           | Go                  |                     | .go                             |                                                                                              |
+| haskell      | Haskell             |                     | .hs                             |                                                                                              |
+| java         | Java                | Main                | .java                           |                                                                                              |
+| javascript   | JavaScript          | main.js             | .js                             |                                                                                              |
+| julia        | Julia               |                     | .jl                             |                                                                                              |
+| kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |
+| lisp         | Common Lisp         | main.{lisp,cl}      | .lisp, .cl                      |                                                                                              |
+| lua          | Lua                 |                     | .lua                            |                                                                                              |
+| modula2      | Modula-2            |                     | .mod, .def                      |                                                                                              |
+| nim          | Nim                 |                     | .nim                            |                                                                                              |
+| objectivec   | Objective-C         |                     | .m                              |                                                                                              |
+| ocaml        | OCaml               |                     | .ml                             |                                                                                              |
+| octave       | Octave              |                     | (.m)                            |                                                                                              |
+| odin         | Odin                |                     | .odin                           |                                                                                              |
+| pascal       | Pascal              |                     | .pas                            |                                                                                              |
+| perl         | Perl                |                     | .pm, (.pl)                      |                                                                                              |
+| php          | PHP                 | main.php            | .php                            |                                                                                              |
+| prolog       | Prolog              |                     | .pl                             |                                                                                              |
+| python2      | Python 2            | main.py2            | (.py), .py2                     | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
+| python3      | Python 3            | main.py             | .py, .py3                       | Matches the regex "`^#!.*python3`"                                                           |
+| python3numpy | Python 3 with NumPy | main.py             | (.py, .py3)                     |                                                                                              |
+| racket       | Racket              |                     | .rkt                            |                                                                                              |
+| ruby         | Ruby                |                     | .rb                             |                                                                                              |
+| rust         | Rust                |                     | .rs                             |                                                                                              |
+| scala        | Scala               |                     | .scala                          |                                                                                              |
+| simula       | Simula              |                     | .sim                            |                                                                                              |
+| smalltalk    | Smalltalk           |                     | .st                             |                                                                                              |
+| snobol       | Snobol              |                     | .sno                            |                                                                                              |
+| swift        | Swift               |                     | .swift                          |                                                                                              |
+| typescript   | TypeScript          |                     | .ts                             |                                                                                              |
+| visualbasic  | Visual Basic        |                     | .vb                             |                                                                                              |
+| zig          | Zig                 |                     | .zig                            |                                                                                              |
 
 ## Problem Statements
 


### PR DESCRIPTION
This PR moves the languages table out of Programs section where it doesn't really fit. Also, it makes it easier to `diff` the files.