### PR TITLE
Add expectations

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -608,7 +608,6 @@ The possible subdirectories are:
 | Value               | Requirement                                                                                                        | Comment
 | ------------------- | ------------------------------------------------------------------------------------------------------------------ | -------
 | accepted            | Accepted as a correct solution for all test cases.                                                                 | At least one is required.
-| partially_accepted  | Overall verdict must be Accepted. Overall score must be less than `max_score`.                                     | Must not be used for pass-fail problems.
 | rejected            | Is rejected (i.e., not accepted) for any reason in the final verdict.                                              |
 | wrong_answer        | Wrong answer for some test case. May be too slow or crash for other test cases.                                    |
 | time_limit_exceeded | Too slow relative to the safety margin for some test case. May output wrong answers or crash for other test cases. |
@@ -628,6 +627,16 @@ Each glob maps to a map with keys as defined below, specifying metadata for all 
 | language   | String                        | As determined by file endings given in the [language list](#languages) |
 | entrypoint | String                        | As specified in the [language list](#languages)                        |
 | authors    | Person or sequence of persons |                                                                        | Author(s) of submission(s)
+| permitted  | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                        | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
+| required   | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                        | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
+| score      | Float                         |                                                                        |
+| message    | String                        | Empty string                                                           | This must appear (case-insensitive) in some `judgemessage.txt`
+
+It is an error if the submissions matched by the glob: 
+- gets a verdict not included in `permitted` for any test case.
+- does not get at least some verdict included in `required` for some test case.
+- does not get a final score of `score`.
+- does not include the string in `message` (case-insensitive) as a substring of the `judgemessage.txt` for some test case. 
 
 ## Input Validators
 


### PR DESCRIPTION
Progress on #145 

Adds a slightly simplified versions of "expectations".

Does not include:
- Expectations on test cases or groups
- Richer globbing
- Expectations on overall verdict
- Ability to express what submissions should be used for timing

Also, explanation should be extended.
