### PR TITLE
Fix mixleading heading

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -830,7 +830,7 @@ An example of a `teammessage.txt` file:
 Almost all test cases failed — are you even trying to solve the problem?
 ```
 
-#### Validator standard output and standard error
+#### Validator standard error
 
 A validator program is allowed to write any kind of debug information to its standard error pipe.
 This information may be displayed to the user upon invocation of the validator.

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -433,7 +433,7 @@ An example of a `teammessage.txt` file:
 Almost all test cases failed — are you even trying to solve the problem?
 ```
 
-#### Validator standard output and standard error
+#### Validator standard error
 
 A validator program is allowed to write any kind of debug information to its standard error pipe.
 This information may be displayed to the user upon invocation of the validator.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -486,7 +486,7 @@ An example of a `teammessage.txt` file:
 Almost all test cases failed — are you even trying to solve the problem?
 ```
 
-#### Validator standard output and standard error
+#### Validator standard error
 
 A validator program is allowed to write any kind of debug information to its standard error pipe.
 This information may be displayed to the user upon invocation of the validator.


### PR DESCRIPTION
The heading refers to standard output, but the text only refers to standard error.