### PR TITLE
Add Java with Algs4 to Languages table

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -298,6 +298,7 @@ File endings in parenthesis are not used for determining language.
 | go           | Go                  |                     | .go                             |
 | haskell      | Haskell             |                     | .hs                             |
 | java         | Java                | Main                | .java                           |
+| javaalgs4    | Java with Algs4     | Main                | (.java)                         |
 | javascript   | JavaScript          | `main.js`           | .js                             |
 | julia        | Julia               |                     | .jl                             |
 | kotlin       | Kotlin              | MainKt              | .kt                             |

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -142,6 +142,7 @@ Only specify limits when the problem needs a specific limit, but do specify limi
 | go           | Go                  |                     | .go                             |                                                                                              |
 | haskell      | Haskell             |                     | .hs                             |                                                                                              |
 | java         | Java                | Main                | .java                           |                                                                                              |
+| javaalgs4    | Java with Algs4     | Main                | (.java)                         |                                                                                              |
 | javascript   | JavaScript          | `main.js`           | .js                             |                                                                                              |
 | julia        | Julia               |                     | .jl                             |                                                                                              |
 | kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -158,6 +158,7 @@ A map with the following keys:
 | go           | Go                  |                     | .go                             |                                                                                              |
 | haskell      | Haskell             |                     | .hs                             |                                                                                              |
 | java         | Java                | Main                | .java                           |                                                                                              |
+| javaalgs4    | Java with Algs4     | Main                | (.java)                         |                                                                                              |
 | javascript   | JavaScript          | `main.js`           | .js                             |                                                                                              |
 | julia        | Julia               |                     | .jl                             |                                                                                              |
 | kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |


### PR DESCRIPTION
Adds the new language "Java with Algs4", which will (soon) be added to Kattis.