### PR TITLE
Expectations, part 2

### DIFF
--- a/appendix/directory_structure.md
+++ b/appendix/directory_structure.md
@@ -60,7 +60,7 @@ These examples are for the latest version of the spec, `2023-07-draft`.
       - a file/directory for each submission with verdict TLE for some testcase
     run_time_error/
       - a file/directory for each submission with verdict RTE for some testcase
-    bruteforce/
+    brute_force/
       - a file/directory for each submission with either verdict RTE or TLE for some testcase
   input_validators/
     - a single output validator, either as a .viva file, a .ctd file, or a program.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -610,12 +610,14 @@ that file must have the language-dependent name as given in the table referred a
 
 ## Example Submissions
 
-Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`.
+Correct and incorrect solutions (file or directory programs) to the problem are
+provided in direct subdirectories of `submissions/`. That is
 By default, the possible subdirectories are as in the table below, but they can
-be customized, see [Default directories](#default-directories).
+be customized and more can be added, see [Default directories](#default-directories).
+Submissions directly in `submissions/`, or two (or more) subdirectories inside it are ignored.
 
 
-| Value                 | Requirement                                                                           | Comment                                                       |
+| Directory             | Requirement                                                                           | Comment                                                       |
 |-----------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | `accepted`            | Accepted as a correct solution for all test cases.                                    | At least one is required. Used to lower bound the time limit. |
 | `rejected`            | At least one case is not accepted.                                                    |                                                               |
@@ -627,11 +629,12 @@ Every file or directory in these directories represents a separate solution.
 It is mandatory to provide at least one accepted solution.
 
 Metadata about the example submissions are provided in a YAML file `submissions/submissions.yaml`.
-The top level keys in `submissions.yaml` are globs matching files or directories in `submissions/`.
+The top level keys in `submissions.yaml` are glob patterns matching files or directories under `submissions/`.
 For example, `accepted` and `accepted/*` match all submissions in the `submissions/accepted/` directory.
-See also [Globs](#globs)
+See also [Glob-patterns](#glob-patterns)
 
-Each glob maps to a map with keys as defined below, specifying metadata for all submissions that are matched by the glob.
+Each glob pattern maps to a map with keys as defined below, specifying metadata for all
+submissions that are matched by the glob pattern.
 
 | Key                  | Type                             | Default                                                                              | Comment                                                                                                   |
 |----------------------|----------------------------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
@@ -644,7 +647,7 @@ Each glob maps to a map with keys as defined below, specifying metadata for all 
 | `message`            | String                           | Empty string                                                                         | This must appear as a substring in at least one `judgemessage.txt`.                                       |
 | `use_for_time_limit` | Bool or string (`lower`/`upper`) | See below.                                                                           | Controls whether this submission is used to determine the time limit.                                     |
 
-Every submission matched by the glob must satisfy:
+Every submission matched by the glob pattern must satisfy:
 - all test cases must have only verdicts present in `permitted`;
 - at least one test case must have a verdict in `required`;
 - if given, the score must be in the given range or equal the given score;
@@ -676,10 +679,10 @@ solves_group_1.py:
     required: TLE
 ```
 
-#### Globs
+#### Glob patterns
 
-Globs can be used to apply restrictions to a subset of submissions.
-It is also possible to use globs to put restrictions on a subset of test
+Glob patterns can be used to apply restrictions to a subset of submissions.
+It is also possible to use glob patterns to put restrictions on a subset of test
 cases, for example when test groups are not used:
 ```yaml
 time_limit_exceeded/solves_easy_cases.py:
@@ -694,11 +697,11 @@ time_limit_exceeded/solves_easy_cases.py:
 This means that the submission must solve all samples and all easy cases, but
 must time out on at least one of the hard cases.
 
-Submission globs are matched against all paths to files and directories of
+Submission glob patterns are matched against all paths to files and directories of
 submissions inside and relative to the `submissions/` directory.
-Test case globs are matched against all paths of test groups and test cases relative to
+Test case glob patterns are matched against all paths of test groups and test cases relative to
 `submissions` and `data/` respectively (, excluding the trailing `.in`. Wildcards (`*`) only match within a file
-name (e.g., do not match `/`). A test case is matched by the glob if either
+name (e.g., do not match `/`). A test case is matched by the glo patternb if either
 itself or any of its parent test groups is matched by it, and similarly a
 submission is matched if either itself or a parent directory is matched.
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -624,6 +624,7 @@ Submissions directly in `submissions/`, or two (or more) subdirectories inside i
 | `wrong_answer`        | At least one case is wrong answer, and all cases are either wrong answer or accepted. | Used to lower bound the time limit.                           |
 | `time_limit_exceeded` | Too slow on at least one case, and all cases are either too slow or accepted.         | Used to upper bound the time limit.                           |
 | `run_time_error`      | Crashes for at least one case, and all cases either crash or are accepted.            | Used to lower bound the time limit.                           |
+| `brute_force`         | Never gives the wrong answer, but not accepted because run time error or timeout.     |                                                               |
 
 Every file or directory in these directories represents a separate solution.
 It is mandatory to provide at least one accepted solution.
@@ -733,7 +734,7 @@ run_time_error:
   required: RTE
 # Must not WA, but fail at least once.
 # Note that by default these are not used for determining the time limit.
-bruteforce:
+brute_force:
   permitted: [AC, RTE, TLE]
   required: [RTE, TLE]
 ```

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -619,30 +619,30 @@ be customized, see [Default directories](#default-directories).
 |-----------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | `accepted`            | Accepted as a correct solution for all test cases.                                    | At least one is required. Used to lower bound the time limit. |
 | `rejected`            | At least one case is not accepted.                                                    |                                                               |
-| `wrong_answer`        | At least one case is wrong answer, and all cases are either wrong answer or accepted. |                                                               |
+| `wrong_answer`        | At least one case is wrong answer, and all cases are either wrong answer or accepted. | Used to lower bound the time limit.                           |
 | `time_limit_exceeded` | Too slow on at least one case, and all cases are either too slow or accepted.         | Used to upper bound the time limit.                           |
-| `run_time_error`      | Crashes for at least one case, and all cases either crash or are accepted.            | Very rarely useful.                                           |
+| `run_time_error`      | Crashes for at least one case, and all cases either crash or are accepted.            | Used to lower bound the time limit.                           |
 
 Every file or directory in these directories represents a separate solution.
 It is mandatory to provide at least one accepted solution.
 
 Metadata about the example submissions are provided in a YAML file `submissions/submissions.yaml`.
 The top level keys in `submissions.yaml` are globs matching files or directories in `submissions/`.
-For example, `accepted` and `accepted/*` match all submission in the `submissions/accepted/` directory.
+For example, `accepted` and `accepted/*` match all submissions in the `submissions/accepted/` directory.
 See also [Globs](#globs)
 
 Each glob maps to a map with keys as defined below, specifying metadata for all submissions that are matched by the glob.
 
-| Key                  | Type                          | Default                                                                              | Comment                                                                                                   |
-|----------------------|-------------------------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `language`           | String                        | As determined by file endings given in the [language list](../appendix/languages.md) |                                                                                                           |
-| `entrypoint`         | String                        | As specified in the [language list](../appendix/languages.md)                        |                                                                                                           |
-| `authors`            | Person or sequence of persons |                                                                                      | Author(s) of submission(s).                                                                               |
-| `permitted`          | Sequence of strings           | `[AC, WA, TLE, RTE]`                                                                 | All test cases must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                            |
-| `required`           | Sequence of strings           | `[AC, WA, TLE, RTE]`                                                                 | At least one test case must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                    |
-| `score`              | Float or list of two floats   |                                                                                      | The score of the submission equals the given number, or is in the given range. Only for scoring problems. |
-| `message`            | String                        | Empty string                                                                         | This must appear as a substring in at least one `judgemessage.txt`.                                       |
-| `use_for_time_limit` | Bool                          | See below.                                                                           | Controls whether this submission is used to determine the time limit.                                     |
+| Key                  | Type                             | Default                                                                              | Comment                                                                                                   |
+|----------------------|----------------------------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `language`           | String                           | As determined by file endings given in the [language list](../appendix/languages.md) |                                                                                                           |
+| `entrypoint`         | String                           | As specified in the [language list](../appendix/languages.md)                        |                                                                                                           |
+| `authors`            | Person or sequence of persons    |                                                                                      | Author(s) of submission(s).                                                                               |
+| `permitted`          | Sequence of strings              | `[AC, WA, TLE, RTE]`                                                                 | All test cases must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                            |
+| `required`           | Sequence of strings              | `[AC, WA, TLE, RTE]`                                                                 | At least one test case must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                    |
+| `score`              | Float or list of two floats      |                                                                                      | The score of the submission equals the given number, or is in the given range. Only for scoring problems. |
+| `message`            | String                           | Empty string                                                                         | This must appear as a substring in at least one `judgemessage.txt`.                                       |
+| `use_for_time_limit` | Bool or string (`lower`/`upper`) | See below.                                                                           | Controls whether this submission is used to determine the time limit.                                     |
 
 Every submission matched by the glob must satisfy:
 - all test cases must have only verdicts present in `permitted`;
@@ -651,7 +651,7 @@ Every submission matched by the glob must satisfy:
 - if given, the `message` string must be included as a case-sensitive substring in the `judgemessage.txt` for at least one test case. 
 
 The tooling should check the constraints for consistency, such as that two
-disjoint `permitted` sets are applied to a single `(submission, testcase)` pair.
+disjoint `permitted` sets are never applied to a single `(submission, testcase)` pair.
 
 ### Groups
 The `permitted`, `required`, `score`, `message`, and `use_for_time_limit`
@@ -682,7 +682,7 @@ Globs can be used to apply restrictions to a subset of submissions.
 It is also possible to use globs to put restrictions on a subset of test
 cases, for example when test groups are not used:
 ```yaml
-time_lmit_exceeded/solves_easy_cases.py:
+time_limit_exceeded/solves_easy_cases.py:
   sample:
     permitted: AC
   secret/*-easy:
@@ -737,8 +737,8 @@ bruteforce:
 
 The defaults can be overwritten in the `submissions.yaml` file by simply specifying the name of the directory.
 Keys that are not specified are inherited from the default configuration above.
-(This is mostly supported for backwards compatibility, and not recommended for
-normal usage.)
+This is supported for backwards compatibility, and not recommended for
+normal usage.
 
 ```yaml
 time_limit_exceeded:
@@ -746,15 +746,15 @@ time_limit_exceeded:
   required: TLE
 ```
 
-(Note that using `time_limit_exceeded/*` instead would impose an _additional_
-requirement, instead of _replacing_ the original requirement.)
+Note that the glob `time_limit_exceeded/*` would impose an _additional_
+requirement, instead of _replacing_ the original requirement.
 
 ### Timelimit inference
 Any submission that must satisfy a `required: TLE` requirement, i.e., must `TLE`
 on at least one test case, is used to provide an _upper bound_ on the time limit.
 Precisely, the time limit must be at most `T / time_limit_to_tle`, where `T` is
 the slowest runtime over the set of test cases to which the rule applies.
-(Note that this excludes submissions that e.g. have `required: [TLE, RTE]`.)
+Note that this excludes submissions that e.g. have `required: [TLE, RTE]`.
 
 Any submission that is not permitted to get `TLE` at all (on some subset of cases), i.e., must satisfy a
 `permitted:` rule that does not contain `TLE`, is used to provide a _lower
@@ -765,12 +765,18 @@ which the rule applies.
 To _opt out_ of a (set of) submission(s) from influencing the time limit, set
 `use_for_time_limit: false` alongside the `permitted:` or `required:` key that
 satisfies the constraints above.
+To _opt out_ of a glob for submission(s) and optional subset of testcases from influencing the time limit, set
+`use_for_time_limit: false` alongside the `permitted:` and/or `required:` keys.
+Note that this means that if you want to exclude a submission completely,
+then you must add `use_for_time_limit: false` to every glob that matches that
+submission and would otherwise include it for determining the time limit.
+
 
 To explicitly _opt in_ a (set of) submissions(s) to be used for determining the time limit,
 use `use_for_time_limit: lower` and `use_for_time_limit: upper`.
 The first is equivalent to a `permitted: [AC, WA, RTE]` constraint, and the
 second to a `required: [TLE]` constraint. The system may warn when this makes
-other constraints redundant.
+other constraints redundant and should error when it is inconsistent with other constraints.
 
 It is required that at least one submission is used to lower bound the time limit.
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -701,7 +701,7 @@ must time out on at least one of the hard cases.
 Submission glob patterns are matched against all paths to files and directories of
 submissions inside and relative to the `submissions/` directory.
 Test case glob patterns are matched against all paths of test groups and test cases relative to
-`submissions` and `data/` respectively (, excluding the trailing `.in`. Wildcards (`*`) only match within a file
+`data/`, excluding the trailing `.in`. Wildcards (`*`) only match within a file
 name (e.g., do not match `/`). A test case is matched by the glo patternb if either
 itself or any of its parent test groups is matched by it, and similarly a
 submission is matched if either itself or a parent directory is matched.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -615,41 +615,43 @@ By default, the possible subdirectories are as in the table below, but they can
 be customized, see [Default directories](#default-directories).
 
 
-| Value               | Requirement                                                                           | Comment                                                   |
-|---------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| accepted            | Accepted as a correct solution for all test cases.                                    | At least one is required. Used to lower bound time limit. |
-| rejected            | At least one case is not accepted.                                                    |                                                           |
-| wrong_answer        | At least one case is wrong answer, and all cases are either wrong answer or accepted. |                                                           |
-| time_limit_exceeded | Too slow on at least one case, and all cases are either too slow or accepted.         | Used to upper bound time limit.                           |
-| run_time_error      | Crashes for at least one case, and all cases either crash or are accepted.            | Very rarely useful.                                       |
+| Value                 | Requirement                                                                           | Comment                                                       |
+|-----------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `accepted`            | Accepted as a correct solution for all test cases.                                    | At least one is required. Used to lower bound the time limit. |
+| `rejected`            | At least one case is not accepted.                                                    |                                                               |
+| `wrong_answer`        | At least one case is wrong answer, and all cases are either wrong answer or accepted. |                                                               |
+| `time_limit_exceeded` | Too slow on at least one case, and all cases are either too slow or accepted.         | Used to upper bound the time limit.                           |
+| `run_time_error`      | Crashes for at least one case, and all cases either crash or are accepted.            | Very rarely useful.                                           |
 
 Every file or directory in these directories represents a separate solution.
 It is mandatory to provide at least one accepted solution.
 
 Metadata about the example submissions are provided in a YAML file `submissions/submissions.yaml`.
-The top level keys in `submissions.yaml` are globs matching files or directories
-in `submissions/`.
-For example, `accepted` and `accepted/*` match all submission in the
-`submissions/accepted/` directory. See also [Globs](#globs)
+The top level keys in `submissions.yaml` are globs matching files or directories in `submissions/`.
+For example, `accepted` and `accepted/*` match all submission in the `submissions/accepted/` directory.
+See also [Globs](#globs)
 
 Each glob maps to a map with keys as defined below, specifying metadata for all submissions that are matched by the glob.
 
-| Key                | Type                          | Default                                                                              | Comment                                                                                                                 |
-|--------------------|-------------------------------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| language           | String                        | As determined by file endings given in the [language list](../appendix/languages.md) |                                                                                                                         |
-| entrypoint         | String                        | As specified in the [language list](../appendix/languages.md)                        |                                                                                                                         |
-| authors            | Person or sequence of persons |                                                                                      | Author(s) of submission(s).                                                                                             |
-| permitted          | String or sequence of strings | `[AC, WA, TLE, RTE]`                                                                 | All test cases must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                                          |
-| required           | String or sequence of strings | `[AC, WA, TLE, RTE]`                                                                 | At least one test case must have a verdict is shit subset of `AC`, `WA`, `TLE`, `RTE`. Must be a subset of `permitted`. |
-| score              | Float or list of two floats   |                                                                                      | The score of the submission equals the given number, or is in the given range. Only for scoring problems.               |
-| message            | String                        | Empty string                                                                         | This must appear as a substring in at least one `judgemessage.txt`.                                                     |
-| use_for_time_limit | Bool                          | See below.                                                                           | Controls whether this submission is used to determine the time limit.                                                   |
+| Key                  | Type                          | Default                                                                              | Comment                                                                                                   |
+|----------------------|-------------------------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `language`           | String                        | As determined by file endings given in the [language list](../appendix/languages.md) |                                                                                                           |
+| `entrypoint`         | String                        | As specified in the [language list](../appendix/languages.md)                        |                                                                                                           |
+| `authors`            | Person or sequence of persons |                                                                                      | Author(s) of submission(s).                                                                               |
+| `permitted`          | Sequence of strings           | `[AC, WA, TLE, RTE]`                                                                 | All test cases must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                            |
+| `required`           | Sequence of strings           | `[AC, WA, TLE, RTE]`                                                                 | At least one test case must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                    |
+| `score`              | Float or list of two floats   |                                                                                      | The score of the submission equals the given number, or is in the given range. Only for scoring problems. |
+| `message`            | String                        | Empty string                                                                         | This must appear as a substring in at least one `judgemessage.txt`.                                       |
+| `use_for_time_limit` | Bool                          | See below.                                                                           | Controls whether this submission is used to determine the time limit.                                     |
 
-Every submission matched by the glob must:
-- only have verdicts present in `permitted`;
-- get at least one verdict in `required`;
-- if given, get a score in the given range or equalling the given score;
-- include the `message` string as a case-sensitive substring in the `judgemessage.txt` for at least one test case. 
+Every submission matched by the glob must satisfy:
+- all test cases must have only verdicts present in `permitted`;
+- at least one test case must have a verdict in `required`;
+- if given, the score must be in the given range or equal the given score;
+- if given, the `message` string must be included as a case-sensitive substring in the `judgemessage.txt` for at least one test case. 
+
+The tooling should check the constraints for consistency, such as that two
+disjoint `permitted` sets are applied to a single `(submission, testcase)` pair.
 
 ### Groups
 The `permitted`, `required`, `score`, `message`, and `use_for_time_limit`
@@ -658,7 +660,7 @@ under a key with the name of a test group (relative to `data/`). In this case,
 the `permitted`, `required`, `message`, and `use_for_time_limit` keys only apply
 to the set of test cases (recursively) in the given group.
 
-The `score` key puts a constraint of the aggregated score of a given test group,
+The `score` key puts a constraint on the aggregated score of a given test group,
 _not_ on the _set_ of test cases the group contains.
 
 For example, the configuration below tests that the submission solves all cases
@@ -701,9 +703,9 @@ itself or any of its parent test groups is matched by it, and similarly a
 submission is matched if either itself or a parent directory is matched.
 
 Using `**` to match any number of directories and `[xyz]` to match only a subset
-of characters is no supported.
-
-TODO: Did we allow `{a,b}.py` in the end?
+of characters is not supported. Brace expansion _is_ supported for both
+submissions and test cases. Thus, one can
+write `{simple,complex}.py` or `author.{py,cpp}` to match multiple files.
 
 ### Default directories
 By default, the following requirements are defined:
@@ -726,15 +728,18 @@ time_limit_exceeded:
 run_time_error:
   permitted: [AC, RTE]
   required: RTE
-# Must not WA, but fail at least once. TODO: name up for debate.
+# Must not WA, but fail at least once.
+# Note that by default these are not used for determining the time limit.
 bruteforce:
   permitted: [AC, RTE, TLE]
   required: [RTE, TLE]
 ```
 
-These requirements may be too strict. To e.g. allow TLE
-submissions to also WA, the default can simply be overwritten in the
-`submissions.yaml` file as:
+The defaults can be overwritten in the `submissions.yaml` file by simply specifying the name of the directory.
+Keys that are not specified are inherited from the default configuration above.
+(This is mostly supported for backwards compatibility, and not recommended for
+normal usage.)
+
 ```yaml
 time_limit_exceeded:
   permitted: [AC, WA, TLE]
@@ -751,7 +756,7 @@ Precisely, the time limit must be at most `T / time_limit_to_tle`, where `T` is
 the slowest runtime over the set of test cases to which the rule applies.
 (Note that this excludes submissions that e.g. have `required: [TLE, RTE]`.)
 
-Any submission that is not allowed to get `TLE` at all (on some subset of cases), i.e., must satisfy a
+Any submission that is not permitted to get `TLE` at all (on some subset of cases), i.e., must satisfy a
 `permitted:` rule that does not contain `TLE`, is used to provide a _lower
 bound_ on the time limit. Precisely, the time limit must be at least `T *
 ac_to_time_limit`, where `T` is the slowest runtime over the set of test cases to
@@ -761,9 +766,13 @@ To _opt out_ of a (set of) submission(s) from influencing the time limit, set
 `use_for_time_limit: false` alongside the `permitted:` or `required:` key that
 satisfies the constraints above.
 
-It is required that at least one submission is used to lower bound the time limit.
+To explicitly _opt in_ a (set of) submissions(s) to be used for determining the time limit,
+use `use_for_time_limit: lower` and `use_for_time_limit: upper`.
+The first is equivalent to a `permitted: [AC, WA, RTE]` constraint, and the
+second to a `required: [TLE]` constraint. The system may warn when this makes
+other constraints redundant.
 
-TODO: Larger sample may be nice.
+It is required that at least one submission is used to lower bound the time limit.
 
 ## Input Validators
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -611,40 +611,159 @@ that file must have the language-dependent name as given in the table referred a
 ## Example Submissions
 
 Correct and incorrect solutions to the problem are provided in subdirectories of `submissions/`.
-The possible subdirectories are:
+By default, the possible subdirectories are as in the table below, but they can
+be customized, see [Default directories](#default-directories).
 
-| Value               | Requirement                                                                                                        | Comment
-| ------------------- | ------------------------------------------------------------------------------------------------------------------ | -------
-| accepted            | Accepted as a correct solution for all test cases.                                                                 | At least one is required.
-| rejected            | Is rejected (i.e., not accepted) for any reason in the final verdict.                                              |
-| wrong_answer        | Wrong answer for some test case. May be too slow or crash for other test cases.                                    |
-| time_limit_exceeded | Too slow relative to the safety margin for some test case. May output wrong answers or crash for other test cases. |
-| run_time_error      | Crashes for some test case. May output wrong answers or be too slow for other test cases.                          | Very rarely useful.
+
+| Value               | Requirement                                                                           | Comment                                                   |
+|---------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| accepted            | Accepted as a correct solution for all test cases.                                    | At least one is required. Used to lower bound time limit. |
+| rejected            | At least one case is not accepted.                                                    |                                                           |
+| wrong_answer        | At least one case is wrong answer, and all cases are either wrong answer or accepted. |                                                           |
+| time_limit_exceeded | Too slow on at least one case, and all cases are either too slow or accepted.         | Used to upper bound time limit.                           |
+| run_time_error      | Crashes for at least one case, and all cases either crash or are accepted.            | Very rarely useful.                                       |
 
 Every file or directory in these directories represents a separate solution.
 It is mandatory to provide at least one accepted solution.
 
-Metadata about the example submissions are provided in a YAML file named `submissions.yaml` placed directly in the `submissions/` directory.
-The top level keys in `submissions.yaml` are globs matching example submissions.
-For example, `accepted/*` would match any submission in the `submissions/accepted/` directory.
+Metadata about the example submissions are provided in a YAML file `submissions/submissions.yaml`.
+The top level keys in `submissions.yaml` are globs matching files or directories
+in `submissions/`.
+For example, `accepted` and `accepted/*` match all submission in the
+`submissions/accepted/` directory. See also [Globs](#globs)
 
 Each glob maps to a map with keys as defined below, specifying metadata for all submissions that are matched by the glob.
 
-| Key        | Type                          | Default                                                                  | Comment
-| ---------- | ----------------------------- | ------------------------------------------------------------------------ | -------
-| language   | String                        | As determined by file endings given in the [language list](../appendix/languages.md) |
-| entrypoint | String                        | As specified in the [language list](../appendix/languages.md)                        |
-| authors    | Person or sequence of persons |                                                                          | Author(s) of submission(s)
-| permitted  | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                          | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
-| required   | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                          | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
-| score      | Float                         |                                                                          |
-| message    | String                        | Empty string                                                             | This must appear (case-insensitive) in some `judgemessage.txt`
+| Key                | Type                          | Default                                                                              | Comment                                                                                                                 |
+|--------------------|-------------------------------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| language           | String                        | As determined by file endings given in the [language list](../appendix/languages.md) |                                                                                                                         |
+| entrypoint         | String                        | As specified in the [language list](../appendix/languages.md)                        |                                                                                                                         |
+| authors            | Person or sequence of persons |                                                                                      | Author(s) of submission(s).                                                                                             |
+| permitted          | String or sequence of strings | `[AC, WA, TLE, RTE]`                                                                 | All test cases must have a verdict in this subset of `AC`, `WA`, `TLE`, `RTE`.                                          |
+| required           | String or sequence of strings | `[AC, WA, TLE, RTE]`                                                                 | At least one test case must have a verdict is shit subset of `AC`, `WA`, `TLE`, `RTE`. Must be a subset of `permitted`. |
+| score              | Float or list of two floats   |                                                                                      | The score of the submission equals the given number, or is in the given range. Only for scoring problems.               |
+| message            | String                        | Empty string                                                                         | This must appear as a substring in at least one `judgemessage.txt`.                                                     |
+| use_for_time_limit | Bool                          | See below.                                                                           | Controls whether this submission is used to determine the time limit.                                                   |
 
-It is an error if the submissions matched by the glob: 
-- gets a verdict not included in `permitted` for any test case.
-- does not get at least some verdict included in `required` for some test case.
-- does not get a final score of `score`.
-- does not include the string in `message` (case-insensitive) as a substring of the `judgemessage.txt` for some test case. 
+Every submission matched by the glob must:
+- only have verdicts present in `permitted`;
+- get at least one verdict in `required`;
+- if given, get a score in the given range or equalling the given score;
+- include the `message` string as a case-sensitive substring in the `judgemessage.txt` for at least one test case. 
+
+### Groups
+The `permitted`, `required`, `score`, `message`, and `use_for_time_limit`
+requirements can also be given for only a subset of test cases, by adding them
+under a key with the name of a test group (relative to `data/`). In this case,
+the `permitted`, `required`, `message`, and `use_for_time_limit` keys only apply
+to the set of test cases (recursively) in the given group.
+
+The `score` key puts a constraint of the aggregated score of a given test group,
+_not_ on the _set_ of test cases the group contains.
+
+For example, the configuration below tests that the submission solves all cases
+in `group1`, but times out on at least one case in `group2`.
+```yaml
+solves_group_1.py:
+  sample:
+    permitted: AC
+  secret/group1:
+    permitted: AC
+  secret/group2:
+    permitted: [AC, TLE]
+    required: TLE
+```
+
+#### Globs
+
+Globs can be used to apply restrictions to a subset of submissions.
+It is also possible to use globs to put restrictions on a subset of test
+cases, for example when test groups are not used:
+```yaml
+time_lmit_exceeded/solves_easy_cases.py:
+  sample:
+    permitted: AC
+  secret/*-easy:
+    permitted: AC
+  secret/*-hard:
+    permitted: [AC, TLE]
+    required: TLE
+```
+This means that the submission must solve all samples and all easy cases, but
+must time out on at least one of the hard cases.
+
+Submission globs are matched against all paths to files and directories of
+submissions inside and relative to the `submissions/` directory.
+Test case globs are matched against all paths of test groups and test cases relative to
+`submissions` and `data/` respectively (, excluding the trailing `.in`. Wildcards (`*`) only match within a file
+name (e.g., do not match `/`). A test case is matched by the glob if either
+itself or any of its parent test groups is matched by it, and similarly a
+submission is matched if either itself or a parent directory is matched.
+
+Using `**` to match any number of directories and `[xyz]` to match only a subset
+of characters is no supported.
+
+TODO: Did we allow `{a,b}.py` in the end?
+
+### Default directories
+By default, the following requirements are defined:
+```yaml
+# All cases must be accepted.
+accepted:
+  permitted: AC
+# At least one case is not accepted.
+rejected:
+  required: [RTE, TLE, WA]
+# All cases AC or WA, at least one WA.
+wrong_answer:
+  permitted: [AC, WA]
+  required: WA
+# All cases AC or TLE, at least one TLE.
+time_limit_exceeded:
+  permitted: [AC, TLE]
+  required: TLE
+# All cases AC or RTE, at least one RTE.
+run_time_error:
+  permitted: [AC, RTE]
+  required: RTE
+# Must not WA, but fail at least once. TODO: name up for debate.
+bruteforce:
+  permitted: [AC, RTE, TLE]
+  required: [RTE, TLE]
+```
+
+These requirements may be too strict. To e.g. allow TLE
+submissions to also WA, the default can simply be overwritten in the
+`submissions.yaml` file as:
+```yaml
+time_limit_exceeded:
+  permitted: [AC, WA, TLE]
+  required: TLE
+```
+
+(Note that using `time_limit_exceeded/*` instead would impose an _additional_
+requirement, instead of _replacing_ the original requirement.)
+
+### Timelimit inference
+Any submission that must satisfy a `required: TLE` requirement, i.e., must `TLE`
+on at least one test case, is used to provide an _upper bound_ on the time limit.
+Precisely, the time limit must be at most `T / time_limit_to_tle`, where `T` is
+the slowest runtime over the set of test cases to which the rule applies.
+(Note that this excludes submissions that e.g. have `required: [TLE, RTE]`.)
+
+Any submission that is not allowed to get `TLE` at all (on some subset of cases), i.e., must satisfy a
+`permitted:` rule that does not contain `TLE`, is used to provide a _lower
+bound_ on the time limit. Precisely, the time limit must be at least `T *
+ac_to_time_limit`, where `T` is the slowest runtime over the set of test cases to
+which the rule applies.
+
+To _opt out_ of a (set of) submission(s) from influencing the time limit, set
+`use_for_time_limit: false` alongside the `permitted:` or `required:` key that
+satisfies the constraints above.
+
+It is required that at least one submission is used to lower bound the time limit.
+
+TODO: Larger sample may be nice.
 
 ## Input Validators
 


### PR DESCRIPTION
I _think_ this includes everything we discussed, but surely some subtleties are still missing.

It would be good to add some more examples, and we should also put the formal cue spec somewhere.

This merges most of what is proposed in #145. Most notably, it does not (yet?) stabilize the 'abbreviations' `submission.py: accepted`. And the other difference is that we merge this into `submissions.yaml` instead of a dedicated `expectations.yaml`.

Also note that to preserve backwards compatibility with the previous definitions of the pre-defined directories, an `expectations.yaml` can be added that relaxes the meaning of `wrong_answer/`, `time_limit_exceeded/`, and `run_time_error/` to simply `permit` all verdicts. But this is not mentioned as such in this version of the spec itself.

Closes #234 closes #145