### PR TITLE
Stronger guidance on the use of \problemname{}

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -419,7 +419,7 @@ The LaTeX class shall provide the convenience environments `Input`, `Output`, an
 It shall also provide the following commands:
 
 - `\problemname`, which expands to the `name` value matching the problem statement's language from `problem.yaml`. 
-  In some cases, the problem name might contain math formulas or other text that should be typeset specially. 
+- In some cases, the problem name might contain math formulas or other text that should be typeset specially. 
   In this case the `\problemname{name}` command, which must be the first line of the problem statement, declares `name` to be a LaTeX-formatted version of the problem name to be used when rendering the problem statement header.
 - `\illustration{width}{filename}{caption}`, a convenience command for adding a figure to the problem statement.
   `width` is a floating-point argument specifying the width of the figure, as a fraction of the total width of the problem statement;

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -418,9 +418,9 @@ It is the judging system's responsibility to wrap this text in an appropriate La
 The LaTeX class shall provide the convenience environments `Input`, `Output`, and `Interaction` for delineating sections of the problem statement.
 It shall also provide the following commands:
 
-- `\problemname{name}`, which must be the first line of the problem statement.
-  `name` gives a LaTeX-formatted problem name to be used when rendering the problem statement header.
-  This argument can be empty, in which case the `name` value matching the problem statement's language from `problem.yaml` is used instead.
+- `\problemname`, which expands to the `name` value matching the problem statement's language from `problem.yaml`. 
+  In some cases, the problem name might contain math formulas or other text that should be typeset specially. 
+  In this case the `\problemname{name}` command, which must be the first line of the problem statement, declares `name` to be a LaTeX-formatted version of the problem name to be used when rendering the problem statement header.
 - `\illustration{width}{filename}{caption}`, a convenience command for adding a figure to the problem statement.
   `width` is a floating-point argument specifying the width of the figure, as a fraction of the total width of the problem statement;
   `filename` is the image to display, and `caption`, the text to include below the figure.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -418,9 +418,9 @@ It is the judging system's responsibility to wrap this text in an appropriate La
 The LaTeX class shall provide the convenience environments `Input`, `Output`, and `Interaction` for delineating sections of the problem statement.
 It shall also provide the following commands:
 
-- `\problemname`, which expands to the `name` value matching the problem statement's language from `problem.yaml`. 
-- In some cases, the problem name might contain math formulas or other text that should be typeset specially. 
-  In this case the `\problemname{name}` command, which must be the first line of the problem statement, declares `name` to be a LaTeX-formatted version of the problem name to be used when rendering the problem statement header.
+- `\problemname`, which must be the first line of the problem statement and places the `name` value matching the problem statement's language from `problem.yaml` into the problem statement header. 
+  In some cases, the problem name might contain math formulas or other text that should be typeset specially. 
+  In this case the `\problemname{name}` command should be used instead and overrides the name in the header with `name`, a LaTeX-formatted version of the problem name.
 - `\illustration{width}{filename}{caption}`, a convenience command for adding a figure to the problem statement.
   `width` is a floating-point argument specifying the width of the figure, as a fraction of the total width of the problem statement;
   `filename` is the image to display, and `caption`, the text to include below the figure.


### PR DESCRIPTION
Discourage use except for when the problem name contains math formulas or other text that should be typeset specially