### PR TITLE
Remove paragraph restricting languages to include file languages

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -654,8 +654,6 @@ If a tool was used to automate creating test case illustration annotations, it i
 Files that should be included with all submissions are provided in one non-empty directory per supported language.
 Files that should be included for all languages are placed in the non-empty directory `include/default/`.
 Files that should be included for a specific language, overriding the default, are provided in the non-empty directory `include/<language>/`.
-If either no included files are provided or default files are provided, then the set of languages in which a submission is allowed to be is unrestricted.
-However, if included files are provided in specific languages, but no default files are provided, then the set of languages is restricted to the specified languages.
 
 The files should be copied from a language directory based on the language of the submission,
 to the submission files before compiling, but after checking whether the submission exceeds the code limit,

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -653,12 +653,12 @@ If a tool was used to automate creating test case illustration annotations, it i
 
 Files that should be included with all submissions are provided in one non-empty directory per supported language.
 Files that should be included for all languages are placed in the non-empty directory `include/default/`.
-Files that should be included for a specific language, overriding the default, are provided in the non-empty directory `include/<language>/`.
+Files that should be included for a specific language, overriding the default, are provided in the non-empty directory `include/<language>/`, where `<language>` is a language code as given in the [languages table](#languages).
 
 The files should be copied from a language directory based on the language of the submission,
 to the submission files before compiling, but after checking whether the submission exceeds the code limit,
 overwriting files from the submission in the case of name collision.
-Language must be given as one of the language codes in the language table in the overview section.
+Language must be one of the allowed submission languages as specified by `languages` in `problem.yaml`.
 If any of the included files are supposed to be the main file (i.e., a driver),
 that file must have the language-dependent name as given in the table referred above.
 


### PR DESCRIPTION
Languages used to be restricted to the languages that `/include` files were available for — since the `languages` key in `problem.yaml` has been added, this is no longer needed and actually make internal contradictions possible (since the set of allowed languages is set by two different factors, which may contradict each other).