### PR TITLE
Move the Languages table to `languages.md`

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -63,13 +63,13 @@ If at least one of these two files is included:
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
 Language is determined by the `language` key in `submissions.yaml` if present (for submissions only);
-otherwise, by looking at the file endings as specified in the [languages table](#languages).
+otherwise, by looking at the file endings as specified in the [languages table](languages.md).
 For validators, this language must be C++ or Python 3.
 If a single language can't be determined, building fails.
 
 For languages where there could be several entry points,
 the entry point specified by the `entrypoint` key in `submissions.yaml` if present (for submissions only) is used;
-otherwise, the default entry point in the [languages table](#languages) will be used.
+otherwise, the default entry point in the [languages table](languages.md) will be used.
 
 The binary (and other artifacts that result from compiling the program) must be placed in the program's directory (or a copy of it).
 Each submission must be run with a working directory that contains (a copy of) the submitted files and any compiled binaries,
@@ -326,66 +326,10 @@ Keywords should not contain spaces.
 
 ### Languages
 
-List of programming languages that this problem should be restricted to or the string `all`.
-Languages are specified using codes from the table below.
+List of programming languages codes from the [languages table](languages.md) or the string `all`.
 If the value is not `all` the problem may only be solved using the listed programming languages.
 
 File endings in parenthesis are not used for determining language.
-
-| Code         | Language            | Default entry point | File endings                    |
-| ------------ | ------------------- | ------------------- | ------------------------------- |
-| ada          | Ada                 |                     | .adb, .ads                      |
-| algol68      | Algol 68            |                     | .a68                            |
-| apl          | APL                 |                     | .apl                            |
-| bash         | Bash                |                     | .sh                             |
-| c            | C                   |                     | .c                              |
-| cgmp         | C with GMP          |                     | (.c)                            |
-| cobol        | COBOL               |                     | .cob                            |
-| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |
-| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |
-| crystal      | Crystal             |                     | .cr                             |
-| csharp       | C\#                 |                     | .cs                             |
-| d            | D                   |                     | .d                              |
-| dart         | Dart                |                     | .dart                           |
-| elixir       | Elixir              |                     | .ex                             |
-| erlang       | Erlang              |                     | .erl                            |
-| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |
-| fortran      | Fortran             |                     | .f90                            |
-| fsharp       | F\#                 |                     | .fs                             |
-| gerbil       | Gerbil              |                     | .ss                             |
-| go           | Go                  |                     | .go                             |
-| haskell      | Haskell             |                     | .hs                             |
-| java         | Java                | Main                | .java                           |
-| javaalgs4    | Java with Algs4     | Main                | (.java)                         |
-| javascript   | JavaScript          | `main.js`           | .js                             |
-| julia        | Julia               |                     | .jl                             |
-| kotlin       | Kotlin              | MainKt              | .kt                             |
-| lisp         | Common Lisp         | `main.{lisp,cl}`    | .lisp, .cl                      |
-| lua          | Lua                 |                     | .lua                            |
-| modula2      | Modula-2            |                     | .mod, .def                      |
-| nim          | Nim                 |                     | .nim                            |
-| objectivec   | Objective-C         |                     | .m                              |
-| ocaml        | OCaml               |                     | .ml                             |
-| octave       | Octave              |                     | (.m)                            |
-| odin         | Odin                |                     | .odin                           |
-| pascal       | Pascal              |                     | .pas                            |
-| perl         | Perl                |                     | .pm, (.pl)                      |
-| php          | PHP                 | `main.php`          | .php                            |
-| prolog       | Prolog              |                     | .pl                             |
-| python2      | Python 2            | `main.py2`          | (.py), .py2                     |
-| python3      | Python 3            | `main.py`           | .py, .py3                       |
-| python3numpy | Python 3 with NumPy | `main.py`           | (.py, .py3)                     |
-| racket       | Racket              |                     | .rkt                            |
-| ruby         | Ruby                |                     | .rb                             |
-| rust         | Rust                |                     | .rs                             |
-| scala        | Scala               |                     | .scala                          |
-| simula       | Simula              |                     | .sim                            |
-| smalltalk    | Smalltalk           |                     | .st                             |
-| snobol       | Snobol              |                     | .sno                            |
-| swift        | Swift               |                     | .swift                          |
-| typescript   | TypeScript          |                     | .ts                             |
-| visualbasic  | Visual Basic        |                     | .vb                             |
-| zig          | Zig                 |                     | .zig                            |
 
 ### Constants
 
@@ -686,15 +630,15 @@ For example, `accepted/*` would match any submission in the `submissions/accepte
 
 Each glob maps to a map with keys as defined below, specifying metadata for all submissions that are matched by the glob.
 
-| Key        | Type                          | Default                                                                | Comment
-| ---------- | ----------------------------- | ---------------------------------------------------------------------- | -------
-| language   | String                        | As determined by file endings given in the [language list](#languages) |
-| entrypoint | String                        | As specified in the [language list](#languages)                        |
-| authors    | Person or sequence of persons |                                                                        | Author(s) of submission(s)
-| permitted  | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                        | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
-| required   | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                        | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
-| score      | Float                         |                                                                        |
-| message    | String                        | Empty string                                                           | This must appear (case-insensitive) in some `judgemessage.txt`
+| Key        | Type                          | Default                                                                  | Comment
+| ---------- | ----------------------------- | ------------------------------------------------------------------------ | -------
+| language   | String                        | As determined by file endings given in the [language list](languages.md) |
+| entrypoint | String                        | As specified in the [language list](languages.md)                        |
+| authors    | Person or sequence of persons |                                                                          | Author(s) of submission(s)
+| permitted  | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                          | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
+| required   | Sequence of strings           | All (i.e. `[AC, WA, TLE, RTE]`)                                          | Values must be non-repeating values from `AC`, `WA`, `TLE`, `RTE`
+| score      | Float                         |                                                                          |
+| message    | String                        | Empty string                                                             | This must appear (case-insensitive) in some `judgemessage.txt`
 
 It is an error if the submissions matched by the glob: 
 - gets a verdict not included in `permitted` for any test case.

--- a/spec/languages.md
+++ b/spec/languages.md
@@ -1,0 +1,58 @@
+# Languages
+
+File endings in parenthesis are not used for determining language.
+
+| Code         | Language            | Default entry point | File endings                    |
+| ------------ | ------------------- | ------------------- | ------------------------------- |
+| ada          | Ada                 |                     | .adb, .ads                      |
+| algol68      | Algol 68            |                     | .a68                            |
+| apl          | APL                 |                     | .apl                            |
+| bash         | Bash                |                     | .sh                             |
+| c            | C                   |                     | .c                              |
+| cgmp         | C with GMP          |                     | (.c)                            |
+| cobol        | COBOL               |                     | .cob                            |
+| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |
+| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |
+| crystal      | Crystal             |                     | .cr                             |
+| csharp       | C\#                 |                     | .cs                             |
+| d            | D                   |                     | .d                              |
+| dart         | Dart                |                     | .dart                           |
+| elixir       | Elixir              |                     | .ex                             |
+| erlang       | Erlang              |                     | .erl                            |
+| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |
+| fortran      | Fortran             |                     | .f90                            |
+| fsharp       | F\#                 |                     | .fs                             |
+| gerbil       | Gerbil              |                     | .ss                             |
+| go           | Go                  |                     | .go                             |
+| haskell      | Haskell             |                     | .hs                             |
+| java         | Java                | Main                | .java                           |
+| javaalgs4    | Java with Algs4     | Main                | (.java)                         |
+| javascript   | JavaScript          | `main.js`           | .js                             |
+| julia        | Julia               |                     | .jl                             |
+| kotlin       | Kotlin              | MainKt              | .kt                             |
+| lisp         | Common Lisp         | `main.{lisp,cl}`    | .lisp, .cl                      |
+| lua          | Lua                 |                     | .lua                            |
+| modula2      | Modula-2            |                     | .mod, .def                      |
+| nim          | Nim                 |                     | .nim                            |
+| objectivec   | Objective-C         |                     | .m                              |
+| ocaml        | OCaml               |                     | .ml                             |
+| octave       | Octave              |                     | (.m)                            |
+| odin         | Odin                |                     | .odin                           |
+| pascal       | Pascal              |                     | .pas                            |
+| perl         | Perl                |                     | .pm, (.pl)                      |
+| php          | PHP                 | `main.php`          | .php                            |
+| prolog       | Prolog              |                     | .pl                             |
+| python2      | Python 2            | `main.py2`          | (.py), .py2                     |
+| python3      | Python 3            | `main.py`           | .py, .py3                       |
+| python3numpy | Python 3 with NumPy | `main.py`           | (.py, .py3)                     |
+| racket       | Racket              |                     | .rkt                            |
+| ruby         | Ruby                |                     | .rb                             |
+| rust         | Rust                |                     | .rs                             |
+| scala        | Scala               |                     | .scala                          |
+| simula       | Simula              |                     | .sim                            |
+| smalltalk    | Smalltalk           |                     | .st                             |
+| snobol       | Snobol              |                     | .sno                            |
+| swift        | Swift               |                     | .swift                          |
+| typescript   | TypeScript          |                     | .ts                             |
+| visualbasic  | Visual Basic        |                     | .vb                             |
+| zig          | Zig                 |                     | .zig                            |

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -53,13 +53,14 @@ If at least one of these two files is included:
    will be invoked in the same way as a single file program.
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
-Language is determined by looking at the file endings as specified in the [languages table](#languages).
+Language is determined by looking at the file endings as specified in the [languages table](languages.md).
+If a single language from the table below can't be determined, building fails.
 In the case of Python 2 and 3 which share the same file ending,
-language will be determined by looking at the shebang line which must match the regular expressions in the [languages table](#languages).
+language will be determined by looking at the shebang line which must match the regular expressions `^#!.*python2` for Python 2 and `^#!.*python3` for Python 3.
 If a single language can't be determined, building fails.
 
 For languages where there could be several entry points,
-the default entry point in the [languages table](#languages) will be used.
+the default entry point in the [languages table](languages.md) will be used.
 
 ## Problem Metadata
 
@@ -161,78 +162,6 @@ A map with the following keys:
 For most keys, the system default will be used if nothing is specified.
 This can vary, but you **should** assume that it's reasonable.
 Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
-
-### Validation
-
-`validation` is a space separated list of strings describing how validation is done.
-Must begin with one of `default` or `custom`.
-If `custom`, may be followed by`interactive`,
-where `interactive` specifies that the validator is run interactively with a submission.
-For example, `custom interactive`.
-
-`validator_flags` will be passed as command-line arguments to each of the output validators.
-
-### Keywords
-
-Space separated list of keywords describing the problem.
-Keywords must not contain spaces.
-
-## Languages
-
-| Code         | Language            | Default entry point | File endings                    | Shebang                                                                                      |
-| ------------ | ------------------- | ------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| ada          | Ada                 |                     | .adb, .ads                      |                                                                                              |
-| algol68      | Algol 68            |                     | .a68                            |                                                                                              |
-| apl          | APL                 |                     | .apl                            |                                                                                              |
-| bash         | Bash                |                     | .sh                             |                                                                                              |
-| c            | C                   |                     | .c                              |                                                                                              |
-| cgmp         | C with GMP          |                     | (.c)                            |                                                                                              |
-| cobol        | COBOL               |                     | .cob                            |                                                                                              |
-| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |                                                                                              |
-| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |                                                                                              |
-| crystal      | Crystal             |                     | .cr                             |                                                                                              |
-| csharp       | C\#                 |                     | .cs                             |                                                                                              |
-| d            | D                   |                     | .d                              |                                                                                              |
-| dart         | Dart                |                     | .dart                           |                                                                                              |
-| elixir       | Elixir              |                     | .ex                             |                                                                                              |
-| erlang       | Erlang              |                     | .erl                            |                                                                                              |
-| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |                                                                                              |
-| fortran      | Fortran             |                     | .f90                            |                                                                                              |
-| fsharp       | F\#                 |                     | .fs                             |                                                                                              |
-| gerbil       | Gerbil              |                     | .ss                             |                                                                                              |
-| go           | Go                  |                     | .go                             |                                                                                              |
-| haskell      | Haskell             |                     | .hs                             |                                                                                              |
-| java         | Java                | Main                | .java                           |                                                                                              |
-| javaalgs4    | Java with Algs4     | Main                | (.java)                         |                                                                                              |
-| javascript   | JavaScript          | `main.js`           | .js                             |                                                                                              |
-| julia        | Julia               |                     | .jl                             |                                                                                              |
-| kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |
-| lisp         | Common Lisp         | `main.{lisp,cl}`    | .lisp, .cl                      |                                                                                              |
-| lua          | Lua                 |                     | .lua                            |                                                                                              |
-| modula2      | Modula-2            |                     | .mod, .def                      |                                                                                              |
-| nim          | Nim                 |                     | .nim                            |                                                                                              |
-| objectivec   | Objective-C         |                     | .m                              |                                                                                              |
-| ocaml        | OCaml               |                     | .ml                             |                                                                                              |
-| octave       | Octave              |                     | (.m)                            |                                                                                              |
-| odin         | Odin                |                     | .odin                           |                                                                                              |
-| pascal       | Pascal              |                     | .pas                            |                                                                                              |
-| perl         | Perl                |                     | .pm, (.pl)                      |                                                                                              |
-| php          | PHP                 | `main.php`          | .php                            |                                                                                              |
-| prolog       | Prolog              |                     | .pl                             |                                                                                              |
-| python2      | Python 2            | `main.py2`          | (.py), .py2                     | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
-| python3      | Python 3            | `main.py`           | .py, .py3                       | Matches the regex "`^#!.*python3`"                                                           |
-| python3numpy | Python 3 with NumPy | `main.py`           | (.py, .py3)                     |                                                                                              |
-| racket       | Racket              |                     | .rkt                            |                                                                                              |
-| ruby         | Ruby                |                     | .rb                             |                                                                                              |
-| rust         | Rust                |                     | .rs                             |                                                                                              |
-| scala        | Scala               |                     | .scala                          |                                                                                              |
-| simula       | Simula              |                     | .sim                            |                                                                                              |
-| smalltalk    | Smalltalk           |                     | .st                             |                                                                                              |
-| snobol       | Snobol              |                     | .sno                            |                                                                                              |
-| swift        | Swift               |                     | .swift                          |                                                                                              |
-| typescript   | TypeScript          |                     | .ts                             |                                                                                              |
-| visualbasic  | Visual Basic        |                     | .vb                             |                                                                                              |
-| zig          | Zig                 |                     | .zig                            |                                                                                              |
 
 ## Problem Statements
 

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -163,6 +163,21 @@ For most keys, the system default will be used if nothing is specified.
 This can vary, but you **should** assume that it's reasonable.
 Only specify limits when the problem needs a specific limit, but do specify limits even if the "typical system default" is what is needed.
 
+### Validation
+
+`validation` is a space separated list of strings describing how validation is done.
+Must begin with one of `default` or `custom`.
+If `custom`, may be followed by `interactive`,
+where `interactive` specifies that the validator is run interactively with a submission.
+For example, `custom interactive`.
+
+`validator_flags` will be passed as command-line arguments to each of the output validators.
+
+### Keywords
+
+Space separated list of keywords describing the problem.
+Keywords must not contain spaces.
+
 ## Problem Statements
 
 The problem statement of the problem is provided in the directory `problem_statement/`.

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -54,7 +54,6 @@ If at least one of these two files is included:
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
 Language is determined by looking at the file endings as specified in the [languages table](languages.md).
-If a single language from the table below can't be determined, building fails.
 In the case of Python 2 and 3 which share the same file ending,
 language will be determined by looking at the shebang line which must match the regular expressions `^#!.*python2` for Python 2 and `^#!.*python3` for Python 3.
 If a single language can't be determined, building fails.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -185,6 +185,11 @@ For example, `custom interactive score`.
 
 `validator_flags` will be passed as command-line arguments to each of the output validators.
 
+### Keywords
+
+Space separated list of keywords describing the problem.
+Keywords must not contain spaces.
+
 ### Scoring
 
 Must only be used on scoring problems.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -185,11 +185,6 @@ For example, `custom interactive score`.
 
 `validator_flags` will be passed as command-line arguments to each of the output validators.
 
-### Keywords
-
-Space separated list of keywords describing the problem.
-Keywords must not contain spaces.
-
 ### Scoring
 
 Must only be used on scoring problems.
@@ -199,6 +194,11 @@ A map with the following keys:
 | --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
 | objective             | String  | max     | One of "min" or "max" specifying whether it is a minimization or a maximization problem. |
 | show_test_data_groups | boolean | false   | Specifies whether test group results should be shown to the end user.                    |
+
+### Keywords
+
+Space separated list of keywords describing the problem.
+Keywords must not contain spaces.
 
 ## Problem Statements
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -52,13 +52,14 @@ If at least one of these two files is included:
    will be invoked in the same way as a single file program.
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
-Language is determined by looking at the file endings as specified in the [languages table](#languages).
+Language is determined by looking at the file endings as specified in the [languages table](languages.md).
+If a single language from the table below can't be determined, building fails.
 In the case of Python 2 and 3 which share the same file ending,
-language will be determined by looking at the shebang line which must match the regular expressions in the [languages table](#languages).
+language will be determined by looking at the shebang line which must match the regular expressions `^#!.*python2` for Python 2 and `^#!.*python3` for Python 3.
 If a single language can't be determined, building fails.
 
 For languages where there could be several entry points,
-the default entry point in the [languages table](#languages) will be used.
+the default entry point in the [languages table](languages.md) will be used.
 
 ### Problem Types
 
@@ -193,68 +194,6 @@ A map with the following keys:
 | --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
 | objective             | String  | max     | One of "min" or "max" specifying whether it is a minimization or a maximization problem. |
 | show_test_data_groups | boolean | false   | Specifies whether test group results should be shown to the end user.                    |
-
-### Keywords
-
-Space separated list of keywords describing the problem.
-Keywords must not contain spaces.
-
-## Languages
-
-| Code         | Language            | Default entry point | File endings                    | Shebang                                                                                      |
-| ------------ | ------------------- | ------------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| ada          | Ada                 |                     | .adb, .ads                      |                                                                                              |
-| algol68      | Algol 68            |                     | .a68                            |                                                                                              |
-| apl          | APL                 |                     | .apl                            |                                                                                              |
-| bash         | Bash                |                     | .sh                             |                                                                                              |
-| c            | C                   |                     | .c                              |                                                                                              |
-| cgmp         | C with GMP          |                     | (.c)                            |                                                                                              |
-| cobol        | COBOL               |                     | .cob                            |                                                                                              |
-| cpp          | C++                 |                     | .cc, .cpp, .cxx, .c++, .C       |                                                                                              |
-| cppgmp       | C++ with GMP        |                     | (.cc, .cpp, .cxx, .c++, .C)     |                                                                                              |
-| crystal      | Crystal             |                     | .cr                             |                                                                                              |
-| csharp       | C\#                 |                     | .cs                             |                                                                                              |
-| d            | D                   |                     | .d                              |                                                                                              |
-| dart         | Dart                |                     | .dart                           |                                                                                              |
-| elixir       | Elixir              |                     | .ex                             |                                                                                              |
-| erlang       | Erlang              |                     | .erl                            |                                                                                              |
-| forth        | Forth               |                     | .fth,. 4th, .forth, .frt, (.fs) |                                                                                              |
-| fortran      | Fortran             |                     | .f90                            |                                                                                              |
-| fsharp       | F\#                 |                     | .fs                             |                                                                                              |
-| gerbil       | Gerbil              |                     | .ss                             |                                                                                              |
-| go           | Go                  |                     | .go                             |                                                                                              |
-| haskell      | Haskell             |                     | .hs                             |                                                                                              |
-| java         | Java                | Main                | .java                           |                                                                                              |
-| javaalgs4    | Java with Algs4     | Main                | (.java)                         |                                                                                              |
-| javascript   | JavaScript          | `main.js`           | .js                             |                                                                                              |
-| julia        | Julia               |                     | .jl                             |                                                                                              |
-| kotlin       | Kotlin              | MainKt              | .kt                             |                                                                                              |
-| lisp         | Common Lisp         | `main.{lisp,cl}`    | .lisp, .cl                      |                                                                                              |
-| lua          | Lua                 |                     | .lua                            |                                                                                              |
-| modula2      | Modula-2            |                     | .mod, .def                      |                                                                                              |
-| nim          | Nim                 |                     | .nim                            |                                                                                              |
-| objectivec   | Objective-C         |                     | .m                              |                                                                                              |
-| ocaml        | OCaml               |                     | .ml                             |                                                                                              |
-| octave       | Octave              |                     | (.m)                            |                                                                                              |
-| odin         | Odin                |                     | .odin                           |                                                                                              |
-| pascal       | Pascal              |                     | .pas                            |                                                                                              |
-| perl         | Perl                |                     | .pm, (.pl)                      |                                                                                              |
-| php          | PHP                 | `main.php`          | .php                            |                                                                                              |
-| prolog       | Prolog              |                     | .pl                             |                                                                                              |
-| python2      | Python 2            | `main.py2`          | (.py), .py2                     | Matches the regex "`^#!.*python2`", and default if shebang does not match any other language |
-| python3      | Python 3            | `main.py`           | .py, .py3                       | Matches the regex "`^#!.*python3`"                                                           |
-| python3numpy | Python 3 with NumPy | `main.py`           | (.py, .py3)                     |                                                                                              |
-| racket       | Racket              |                     | .rkt                            |                                                                                              |
-| ruby         | Ruby                |                     | .rb                             |                                                                                              |
-| rust         | Rust                |                     | .rs                             |                                                                                              |
-| scala        | Scala               |                     | .scala                          |                                                                                              |
-| simula       | Simula              |                     | .sim                            |                                                                                              |
-| smalltalk    | Smalltalk           |                     | .st                             |                                                                                              |
-| snobol       | Snobol              |                     | .sno                            |                                                                                              |
-| swift        | Swift               |                     | .swift                          |                                                                                              |
-| typescript   | TypeScript          |                     | .ts                             |                                                                                              |
-| visualbasic  | Visual Basic        |                     | .vb                             |                                                                                              |
-| zig          | Zig                 |                     | .zig                            |                                                                                              |
 
 ## Problem Statements
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -53,7 +53,6 @@ If at least one of these two files is included:
 
 Programs without `build` and `run` scripts are built and run according to what language is used.
 Language is determined by looking at the file endings as specified in the [languages table](languages.md).
-If a single language from the table below can't be determined, building fails.
 In the case of Python 2 and 3 which share the same file ending,
 language will be determined by looking at the shebang line which must match the regular expressions `^#!.*python2` for Python 2 and `^#!.*python3` for Python 3.
 If a single language can't be determined, building fails.


### PR DESCRIPTION
Closes #269

Moves the Languages table to `languages.md`. Removes the `Shebang` column in `legacy.md` and `icpc-legacy.md` — the equivalent date is moved up to whence it is referenced.