### PR TITLE
Use recommended case for BCP 47

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -134,8 +134,8 @@ A deliberately complex and construed example:
 ```yaml
 name:
   en: Hello World!
-  pt-br: Olá mundo!
-  pt-pt: Oi mundo!
+  pt-BR: Olá mundo!
+  pt-PT: Oi mundo!
   fil: Kumusta mundo!
 ```
 


### PR DESCRIPTION
It's recommended (for readability?) that the country code in BCP 47 style language codes is upper case.