### PR TITLE
Explicitly mention CC license versions

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -259,15 +259,15 @@ source:
 License under which the problem may be used.
 Must be one of the values below.
 
-| Value         | Comments                                                                           | Link                                             |
-| ------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------ |
-| unknown       | The default value. In practice means that the problem can not be used.             |                                                  |
-| public domain | There are no known copyrights on the problem, anywhere in the world.               | <http://creativecommons.org/about/pdm>           |
-| cc0           | CC0, "no rights reserved".                                                         | <http://creativecommons.org/about/cc0>           |
-| cc by         | CC attribution.                                                                    | <http://creativecommons.org/licenses/by/4.0/>    |
-| cc by-sa      | CC attribution, share alike.                                                       | <http://creativecommons.org/licenses/by-sa/4.0/> |
-| educational   | May be freely used for educational purposes.                                       |                                                  |
-| permission    | Used with permission. The rights owner must be contacted for every additional use. |                                                  |
+| Value         | Comments                                                                           | Link                                                 |
+| ------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| unknown       | The default value. In practice means that the problem can not be used.             |                                                      |
+| public domain | There are no known copyrights on the problem, anywhere in the world.               | <http://creativecommons.org/about/pdm>               |
+| cc0           | CC0, "no rights reserved", version 1 or later.                                     | <https://creativecommons.org/publicdomain/zero/1.0/> |
+| cc by         | CC attribution license, version 4 or later.                                        | <http://creativecommons.org/licenses/by/4.0/>        |
+| cc by-sa      | CC attribution, share alike license, version 4 or later.                           | <http://creativecommons.org/licenses/by-sa/4.0/>     |
+| educational   | May be freely used for educational purposes.                                       |                                                      |
+| permission    | Used with permission. The rights owner must be contacted for every additional use. |                                                      |
 
 `rights_owner` is the owner of the copyright of the problem.
 Values other than _unknown_ or _public domain_ require `rights_owner` to have a value.

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -126,15 +126,15 @@ and the `source_url` key contains a link to the event's page.
 License under which the problem may be used.
 Must be one of the values below.
 
-| Value         | Comments                                                                           | Link                                             |
-| ------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------ |
-| unknown       | The default value. In practice means that the problem can not be used.             |                                                  |
-| public domain | There are no known copyrights on the problem, anywhere in the world.               | <http://creativecommons.org/about/pdm>           |
-| cc0           | CC0, "no rights reserved".                                                         | <http://creativecommons.org/about/cc0>           |
-| cc by         | CC attribution.                                                                    | <http://creativecommons.org/licenses/by/4.0/>    |
-| cc by-sa      | CC attribution, share alike.                                                       | <http://creativecommons.org/licenses/by-sa/4.0/> |
-| educational   | May be freely used for educational purposes.                                       |                                                  |
-| permission    | Used with permission. The rights owner must be contacted for every additional use. |                                                  |
+| Value         | Comments                                                                           | Link                                                 |
+| ------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| unknown       | The default value. In practice means that the problem can not be used.             |                                                      |
+| public domain | There are no known copyrights on the problem, anywhere in the world.               | <http://creativecommons.org/about/pdm>               |
+| cc0           | CC0, "no rights reserved", version 1 or later.                                     | <https://creativecommons.org/publicdomain/zero/1.0/> |
+| cc by         | CC attribution license, version 4 or later.                                        | <http://creativecommons.org/licenses/by/4.0/>        |
+| cc by-sa      | CC attribution, share alike license, version 4 or later.                           | <http://creativecommons.org/licenses/by-sa/4.0/>     |
+| educational   | May be freely used for educational purposes.                                       |                                                      |
+| permission    | Used with permission. The rights owner must be contacted for every additional use. |                                                      |
 
 `rights_owner` is the owner of the copyright of the problem.
 Values other than _unknown_ or _public domain_ require `rights_owner` to have a value.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -137,15 +137,15 @@ and the `source_url` key contains a link to the event's page.
 License under which the problem may be used.
 Must be one of the values below.
 
-| Value         | Comments                                                                           | Link                                             |
-| ------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------ |
-| unknown       | The default value. In practice means that the problem can not be used.             |                                                  |
-| public domain | There are no known copyrights on the problem, anywhere in the world.               | <http://creativecommons.org/about/pdm>           |
-| cc0           | CC0, "no rights reserved".                                                         | <http://creativecommons.org/about/cc0>           |
-| cc by         | CC attribution.                                                                    | <http://creativecommons.org/licenses/by/4.0/>    |
-| cc by-sa      | CC attribution, share alike.                                                       | <http://creativecommons.org/licenses/by-sa/4.0/> |
-| educational   | May be freely used for educational purposes.                                       |                                                  |
-| permission    | Used with permission. The rights owner must be contacted for every additional use. |                                                  |
+| Value         | Comments                                                                           | Link                                                 |
+| ------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| unknown       | The default value. In practice means that the problem can not be used.             |                                                      |
+| public domain | There are no known copyrights on the problem, anywhere in the world.               | <http://creativecommons.org/about/pdm>               |
+| cc0           | CC0, "no rights reserved", version 1 or later.                                     | <https://creativecommons.org/publicdomain/zero/1.0/> |
+| cc by         | CC attribution license, version 4 or later.                                        | <http://creativecommons.org/licenses/by/4.0/>        |
+| cc by-sa      | CC attribution, share alike license, version 4 or later.                           | <http://creativecommons.org/licenses/by-sa/4.0/>     |
+| educational   | May be freely used for educational purposes.                                       |                                                      |
+| permission    | Used with permission. The rights owner must be contacted for every additional use. |                                                      |
 
 `rights_owner` is the owner of the copyright of the problem.
 Values other than _unknown_ or _public domain_ require `rights_owner` to have a value.


### PR DESCRIPTION
This means that if the owner of a problem package has licensed his problem hypothetically in the future under CC by-sa 5, then he can still select `cc -by-sa` here without the specification implying that it would actually be licensed under version 4.

For future versions of the specification we can bump the CC license version to the latest version (if any new version was released), assuming that we want to require problem owners to always license under the latest version of a CC license.