### PR TITLE
Remove YAML key-value variant of Person object

### DIFF
--- a/examples/problems/maximal/problem.yaml
+++ b/examples/problems/maximal/problem.yaml
@@ -7,12 +7,11 @@ uuid: b2792508-b645-480a-8357-da047d57a17d
 credits:
   authors:
     - Author One <author1@judge.com>
-    - name: Author Two
-      email: author2@judge.com
+    - Author Two <author2@judge.com>
   contributors: Contributor <contributor@email.com>
   testers:
-    - name: Tester 1
-    - name: Tester 2 <second@tester.com>
+    - Tester 1
+    - Tester 2 <second@tester.com>
   translators:
     sv: Sven Translator <sven@translator.com>
   acknowledgements: [Inspirational Speaker 1, Inspirational Speaker 2]

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -160,7 +160,7 @@ This specification currently does not imply any more semantic meaning to these f
 ### Credits
 
 Map specifying who should get credits for creating this problem.
-A person is specified as a string with their full name, optionally followed by an email wrapped in `<>`, (e.g.: `Full Name` or `Full Name <fullname@problem.example>`).
+A person is specified as a string with the full name, optionally followed by an email wrapped in `<>`, (e.g.: `Full Name` or `Full Name <fullname@problem.example>`).
 
 | Key               | Type                                   | Comments
 | ----------------- | ---------------------------------------| --------

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -160,7 +160,7 @@ This specification currently does not imply any more semantic meaning to these f
 ### Credits
 
 Map specifying who should get credits for creating this problem.
-A person is specified as either a string with their full name (optionally with an email formatted as `Full Name <fullname@problem.example>`), or a map with keys `name` and `email`, which both have values of type string.
+A person is specified as a string with their full name, optionally followed by an email wrapped in `<>`, (e.g.: `Full Name` or `Full Name <fullname@problem.example>`).
 
 | Key               | Type                                   | Comments
 | ----------------- | ---------------------------------------| --------
@@ -171,39 +171,20 @@ A person is specified as either a string with their full name (optionally with a
 | packagers         | Person or sequence of persons          | The people who created the problem package out of an existing problem.
 | acknowledgements  | Person or sequence of persons          | Extra acknowledgements or special thanks in addition to the previously mentioned.
 
-The examples
-```yaml
-credits:
-  authors: [Author One, Author Two <author.2@problem.example>]
-```
-and
-```yaml
-credits:
-  authors:
-  - name: Author One
-  - name: Author Two
-    email: author.2@problem.example
-```
-are both valid ways to describe the same two authors.
-
 A full example would be
 ```yaml
 credits:
   authors: Authy McAuth <authy@mcauth.example>
   contributors:
   - Authy McAuth <authy@mcauth.example>
-  - name: Additional Contributor
-    email: extra@contrib.example
+  - Additional Contributor <extra@contrib.example>
   testers:
   - Tester One
   - Tester Two
   - Tester Three
   translators:
-    da:
-    - name: Mads Jensen
-      email: mads@mads.example
-    eo:
-    - Ludoviko Lazaro Zamenhofo
+    da: Mads Jensen <mads@mads.example>
+    eo: Ludoviko Lazaro Zamenhofo
   acknowledgements:
     - Inspirational Speaker 1
     - Inspirational Speaker 2


### PR DESCRIPTION
A Person (used mostly in the Credits section) was previously defined to be either a plain name (`name`), a *name-addr* (`name <email>`), or a pair of YAML key-value pairs, e.g.:
```yaml
credits:
  authors:
  - name: Author Name
    email: author.name@problem.example
```

This PR removes the last option so that the only allowed formats are `name` and `name <email>`.