### PR TITLE
Add Jekyll metadata to `spec/languages.md`

### DIFF
--- a/spec/languages.md
+++ b/spec/languages.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Languages
+sort: 5
+---
+
 # Languages
 
 File endings in parenthesis are not used for determining language.


### PR DESCRIPTION
Adds Jekyll metadata to the `spec/languages.md` document added in #272 to make it render correctly in the sidebar in Jekyll