### PR TITLE
Fix broken links

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -191,7 +191,7 @@ A person is specified as a string with the full name, optionally followed by an 
 | authors           | Person or sequence of persons          | The people who conceptualized the problem.
 | contributors      | Person or sequence of persons          | The people who developed the problem package, such as statement, validators, and test data.
 | testers           | Person or sequence of persons          | The people who tested the problem package, for example by providing a solution and reviewing the statement.
-| translators       | Map of strings to sequences of persons | The people who translated the statement to other languages. Each key must be a language code as described in [General Requirements](#general-requirements "wikilink").
+| translators       | Map of strings to sequences of persons | The people who translated the statement to other languages. Each key must be a language code as described in [General Requirements](#general-requirements).
 | packagers         | Person or sequence of persons          | The people who created the problem package out of an existing problem.
 | acknowledgements  | Person or sequence of persons          | Extra acknowledgements or special thanks in addition to the previously mentioned.
 
@@ -705,9 +705,9 @@ A validator program must be an application (executable or interpreted) capable o
 The details of this invocation are described below.
 The validator program has two ways of reporting back the results of validating:
 
-1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
+1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement)).
 2.  The validator may give additional feedback,
-    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
+    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback)).
 
 A custom output validator is used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
 It must be provided as the directory `output_validator/`.

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -321,12 +321,12 @@ A validator program must be an application (executable or interpreted) capable o
 The details of this invocation are described below.
 The validator program has two ways of reporting back the results of validating:
 
-1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
+1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement)).
 2.  The validator may give additional feedback,
-    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
+    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback)).
 
 Custom output validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
-They are provided in `output_validators/`, and must adhere to the [Output validator](#output-validators "wikilink") specification.
+They are provided in `output_validators/`, and must adhere to the [Output validator](#output-validators) specification.
 
 All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of.
 Validation fails if any validator fails.

--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -326,7 +326,7 @@ The validator program has two ways of reporting back the results of validating:
     e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
 Custom output validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
-They are provided in `output_validators/`, and must adhere to the [Output validator](output_validators "wikilink") specification.
+They are provided in `output_validators/`, and must adhere to the [Output validator](#output-validators "wikilink") specification.
 
 All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of.
 Validation fails if any validator fails.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -277,7 +277,7 @@ At the top level, the test data is divided into exactly two groups: `sample` and
 These two groups may be further split into subgroups as desired.
 
 The *result* of a test data group is computed by applying a *grader* to all of the sub-results (test cases and subgroups) in the group.
-See [Graders](#graders "wikilink") for more details.
+See [Graders](#graders) for more details.
 
 Test cases and groups will be used in lexicographical order on file base name.
 If a specific order is desired a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
@@ -380,12 +380,12 @@ A validator program must be an application (executable or interpreted) capable o
 The details of this invocation are described below.
 The validator program has two ways of reporting back the results of validating:
 
-1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement "wikilink")).
+1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement)).
 2.  The validator may give additional feedback,
-    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
+    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback)).
 
 Custom output validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
-They are provided in `output_validators/`, and must adhere to the [Output validator](#output-validators "wikilink") specification.
+They are provided in `output_validators/`, and must adhere to the [Output validator](#output-validators) specification.
 
 All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of.
 Validation fails if any validator fails.
@@ -561,7 +561,7 @@ four different modes for aggregating the score
 -- _sum_, _avg_, _min_, _max_ --
 and two flags
 -- _ignore_sample_ and _accept_if_any_accepted_.
-These modes can be set by providing their names as command line arguments (through the "grader_flags" option in [`testdata.yaml`](#test-data-groups "wikilink")).
+These modes can be set by providing their names as command line arguments (through the "grader_flags" option in [`testdata.yaml`](#test-data-groups)).
 If multiple conflicting modes are given, the last one is used. Their meaning are as follows.
 
 | Argument                 | Type         | Description

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -385,7 +385,7 @@ The validator program has two ways of reporting back the results of validating:
     e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback "wikilink")).
 
 Custom output validators are used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
-They are provided in `output_validators/`, and must adhere to the [Output validator](output_validators "wikilink") specification.
+They are provided in `output_validators/`, and must adhere to the [Output validator](#output-validators "wikilink") specification.
 
 All output validators provided will be run on the output for every test data file using the arguments specified for the test data group they are part of.
 Validation fails if any validator fails.


### PR DESCRIPTION
- Fixes the broken link `[...](output_validators)` → `[...](#output-validators)`
- Remove link "wikilink" titles (i.e., `[...](... "wikilink")` → `[...](...)`