### PR TITLE
Remove input visualizer from legacy

### DIFF
--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -47,7 +47,6 @@ File or Folder         | Required? | Described In                               
 `include/`             | No        | [Included Files](#included-files)             | Files appended to all submitted solutions
 `submissions/`         | Yes       | [Example Submissions](#example-submissions)   | Correct and incorrect judge solutions of the problem
 `input_validators/`    | Yes       | [Input Validators](#input-validators)         | Programs that verifies correctness of the test data inputs
-`input_visualizer/`    | No        | [Input Visualizer](#input-visualizer)         | Scripts and documentation about how test case illustrations were generated
 `output_validators/`   | No        | [Output Validators](#output-validators)       | Custom programs for judging solutions
 
 A minimal problem package must contain `problem.yaml`, a problem statement, a secret test case, an accepted judge solution, and an input validator.


### PR DESCRIPTION
I don't know when/how/why that was put in there?

It was clearly an error, it was only in the summary, and the link was broken because the section does not exist.

Also, we all know it shouldn't be there :).