### PR TITLE
Cleanup of the Sample section

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -596,70 +596,70 @@ The directory `invalid` can be organized into a tree-like structure similar to `
 ### Samples
 
 Sample test cases can be used in three places:
-- All submissions are run on the samples, and possibly feedback is provided to teams.
-- The samples are shown in the problem statement.
-- The samples are available for download.
+- As test cases for team submissions (with feedback possibly provided to the teams).
+- As sample input and output displayed in the problem statement.
+- As sample input and output files available for download.
 
 By default the sample data for all three cases is taken from the `.in` and `.ans` file pairs under `data/sample`.
 Some problems require (slightly) different data in each of these cases.
-We allow customizing this in subdirectories `data/sample/statement` and `data/sample/download`.
+We allow customizing which data is used for each purpose using the subdirectories `data/sample/statement` and `data/sample/download`.
 In this case it is recommended to symlink identical files from these subdirectories to those in `data/sample`.
 
-#### Samples used by the judge
+#### Samples For Judging Team Submissions
 
 The `data/sample` directory contains test cases similar to those in `data/secret`.
-Every submission is run against these.
+Every submission is run on these test cases (but sample test cases do not contribute to the problem score for [scoring problems](#scoring-problems)).
 
-`data/sample` must not contain test groups.
-Also, it does not _have to_ contain any test cases, for example when the samples shown in the PDF are not actually valid cases.
+`data/sample` must not contain test groups. It may be missing (for problems with no samples) or empty.
 
-#### Samples shown in the problem statement
+#### Samples Shown in the Problem Statement
 
 By default, the `.in` and `.ans` pairs from `data/sample` are shown in the problem statement.
-This can be customized by creating the `data/sample/statement` directory.
+This behavior can be customized by creating the `data/sample/statement` directory.
 If this directory exists, its contents replaces that of `data/sample` for purposes of the problem statement.
-This directory is _required_ for interactive problems.
-
-For each test case, `data/sample/statement` must contain one of the following for default or custom validation (non-interactive) problems:
-- An `.in` and `.ans` file, which are both shown.
-- An `.in`, `.ans`, and `.out` file, of which the `.in` and `.out` file are shown, and the `.ans` file is used for validation.
+Interactive problems with sample test cases should almost always make use of this directory, since the `.in` and `.ans` pairs do not meaningfully capture how users are expected to interact with the output validator in such problems.
 
 ##### Interactive Problems
 
-For interactive problems, `data/sample/statement` must contain one of:
-- An `.in` and `.out` file, which are both shown, neither of which is validated.
+For interactive problems, sample data in `data/sample/statement` must have one of the following forms:
+- An `.in` and `.out` file, which are both shown, and neither of which is validated.
 - An `.interaction` file that contains lines starting with `<` and `>`,
   containing an interaction log with output from the output validator starting with `<` and output from the submission starting with `>`.
-    - An `.interaction` file **may** be specified without a corresponding test case —
-      any such interaction log will be displayed as usual.
 
-If you want to provide files related to interactive problems (such as testing tools or input files), you can use [data/sample/download](#samples-available-for-download).
+Note that an `.interaction` file does **not** need to be accompanied by corresponding `.in` and `.out` files. If both an `.interaction` file and corresponding `.in` and `.out` files are present, only the interaction log in the `.interaction` file is shown in the problem statement.
 
-#### Samples available for download
+If you want to make testing tools available for download, you can use [attachments](#attachments).
+
+##### Other Problem Types
+
+For each test case, `data/sample/statement` must contain one of the following:
+- An `.in` and `.ans` file, which are both shown.
+- An `.in`, `.ans`, and `.out` file, of which the `.in` and `.out` file are shown, and the `.ans` file is used for validation (see below).
+
+
+#### Samples Available for Download
 
 When `data/sample/download` exists, the files in there are available for download.
 If this directory does not exist, the contents of `data/sample/statement` are available for download,
-with any `.out` files renamed to `.ans` (replacing existing `.ans` files).
+with any `.out` files renamed to `.ans` (replacing existing `.ans` files) and all `.interaction` files removed.
 When that also does not exist, the test cases in `data/sample` are available for download.
-`data/sample/download` is required for interactive problems.
 
-The `data/sample/download` directory may contain anything, including, e.g., a testing tool for interactive problems, and is not validated.
+The `data/sample/download` directory may contain anything, and none of its contents are validated. We recommend placing test-case-specific files in this directory, and using [attachments](#attachments) for testing tools and other downloads not associated with any particular test case.
 Testing tools may warn when test cases that are listed in `data/sample` or `data/sample/statement` do not appear in `data/sample/download`,
 or when `data/sample/download` contains test cases that do not appear in one of the two other locations.
 
 #### Validation
 
-All `data/sample/*.in` files are input-validated.
+All `data/sample/*.in` files are input-validated. For problems that are not interactive, all `data/sample/statement/*.in` are also input-validated.
 
-When `data/sample/statement/` does not exist, `data/sample/*.ans` is output validated (i.e., must be accepted).
-
-When `data/sample/statement/` does exists, and the problem is not interactive,
-all `data/sample/statement/*.in` are input validated, and `data/sample/statement/*.out` (with fallback to `data/sample/statement/*.ans`) are output validated (i.e., must be accepted).
+When `data/sample/statement/` does not exist, all test cases in `data/sample` must be accepted by the output validator, with the `.ans` file used as both the `answer_file` and `team_output`.
+ 
+When `data/sample/statement/` does exists, and the problem is not interactive, all test cases in `data/sample/statement/` must be accepted by the output validator. The `.ans` is used as the `answer_file`. The `.out` file is used as the `team_output`, if it exists. Otherwise the `.ans` is used as the `team_output`. 
 
 Files in `data/sample/download` are never validated, 
 although tooling may warn when there are inconsistencies between `download`, `statement`, and `data/sample/` itself.
 
-Validation can be customized by specifying `input_validator_args` and `output_validator_args` in `data/sample/testdata.yaml`.
+Validation can be customized by specifying `input_validator_args` and `output_validator_args` in `data/sample/testdata.yaml`. These arguments are used when validating test cases in both `/data/sample` and `/data/sample/statement`.
 
 ## Generators
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -646,7 +646,8 @@ If this directory does not exist, the contents of `data/sample/statement` are av
 with any `.out` files renamed to `.ans` (replacing existing `.ans` files) and all `.interaction` files removed.
 When that also does not exist, the test cases in `data/sample` are available for download.
 
-The `data/sample/download` directory may contain anything, and none of its contents are validated. We recommend placing test-case-specific files in this directory, and using [attachments](#attachments) for testing tools and other downloads not associated with any particular test case.
+The `data/sample/download` directory may contain anything, and none of its contents are validated. 
+We recommend placing test-case-specific files in this directory, and using [attachments](#attachments) for testing tools and other downloads not associated with any particular test case.
 Testing tools may warn when test cases that are listed in `data/sample` or `data/sample/statement` do not appear in `data/sample/download`,
 or when `data/sample/download` contains test cases that do not appear in one of the two other locations.
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -608,7 +608,8 @@ In this case it is recommended to symlink identical files from these subdirector
 #### Samples For Judging Team Submissions
 
 The `data/sample` directory contains test cases similar to those in `data/secret`.
-Every submission is run on these test cases (but sample test cases do not contribute to the problem score for [scoring problems](#scoring-problems)).
+Every submission is run on these test cases 
+(but sample test cases do not contribute to the problem score for [scoring problems](#scoring-problems)).
 
 `data/sample` must not contain test groups. It may be missing (for problems with no samples) or empty.
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -659,7 +659,8 @@ When `data/sample/statement/` does exists, and the problem is not interactive, a
 Files in `data/sample/download` are never validated, 
 although tooling may warn when there are inconsistencies between `download`, `statement`, and `data/sample/` itself.
 
-Validation can be customized by specifying `input_validator_args` and `output_validator_args` in `data/sample/testdata.yaml`. These arguments are used when validating test cases in both `/data/sample` and `/data/sample/statement`.
+Validation can be customized by specifying `input_validator_args` and `output_validator_args` in `data/sample/testdata.yaml`. 
+These arguments are used when validating test cases in both `/data/sample` and `/data/sample/statement`.
 
 ## Generators
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -598,7 +598,7 @@ The directory `invalid` can be organized into a tree-like structure similar to `
 Sample test cases can be used in three places:
 - As test cases for team submissions (with feedback possibly provided to the teams).
 - As sample input and output displayed in the problem statement.
-- As sample input and output files available for download.
+- As sample input and output files available for download, or otherwise made available.
 
 By default the sample data for all three cases is taken from the `.in` and `.ans` file pairs under `data/sample`.
 Some problems require (slightly) different data in each of these cases.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -611,7 +611,8 @@ The `data/sample` directory contains test cases similar to those in `data/secret
 Every submission is run on these test cases 
 (but sample test cases do not contribute to the problem score for [scoring problems](#scoring-problems)).
 
-`data/sample` must not contain test groups. It may be missing (for problems with no samples) or empty.
+`data/sample` must not contain test groups. 
+It may be missing (for problems with no samples) or empty.
 
 #### Samples Shown in the Problem Statement
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -654,7 +654,10 @@ All `data/sample/*.in` files are input-validated. For problems that are not inte
 
 When `data/sample/statement/` does not exist, all test cases in `data/sample` must be accepted by the output validator, with the `.ans` file used as both the `answer_file` and `team_output`.
  
-When `data/sample/statement/` does exists, and the problem is not interactive, all test cases in `data/sample/statement/` must be accepted by the output validator. The `.ans` is used as the `answer_file`. The `.out` file is used as the `team_output`, if it exists. Otherwise the `.ans` is used as the `team_output`. 
+When `data/sample/statement/` does exists, and the problem is not interactive, all test cases in `data/sample/statement/` must be accepted by the output validator. 
+The `.ans` is used as the `answer_file`. 
+The `.out` file is used as the `team_output`, if it exists. 
+Otherwise the `.ans` is used as the `team_output`. 
 
 Files in `data/sample/download` are never validated, 
 although tooling may warn when there are inconsistencies between `download`, `statement`, and `data/sample/` itself.


### PR DESCRIPTION
I've done a pass on this section. The requirements here are quite complex so please double-check everything carefully.

In particular:
 - I've encouraged use of attachments where appropriate (per https://github.com/Kattis/problem-package-format/issues/338).
 - Is it true that all submissions are run on the test cases in data/sample? Including in scoring problems (despite these test cases not being included in the score) and interactive problems?
 - I've softened the hard requirement that interactive problems must have `sample/statement` and `sample/download`.
 - Clarified that if both `.interaction` and `.in` and `.out` is provided, only the former is shown (is this true)?
 - A strict reading of the spec suggested that interactive problems could only have a single test case in `sample/statement`. I assume that was unintentional?
 - Clarified that downloads do not include the `.interaction` files by default (is this true?)
 - Clarified what is means to validate the `.ans` files.
 - Clarified that `validator_args` in `data/sample` also apply to `data/sample/statement` (is this true?)