### PR TITLE
Consistently allow C/C++ and Python 3 for programs

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -110,7 +110,7 @@ If at least one of these two files is included:
 2. Then, the `run` file (which now exists, and is an executable binary or POSIX-compliant shell script)
    will be used as the validator or visualizer program.
 
-Scripts may assume a POSIX-compliant shell and that a Python 3 interpreter, C compiler, and C++ compiler are available on the system search path, aliased to `python3`, `cc`, and `cpp` respectively. 
+Scripts may assume a POSIX-compliant shell and that a Python 3 interpreter, C compiler, and C++ compiler are available on the system search path, aliased to `python3`, `cc`, and `c++` respectively.
 Problem packages with `build` or `run` scripts are strongly encouraged to include a `README` file in the program directory documenting any such additional dependencies.
 
 Programs that do not include a `build` or `run` script must have one of the following forms:
@@ -881,9 +881,7 @@ It is required that at least one submission is used to lower bound the time limi
 Input Validators, verifying the correctness of the input files, are provided in `input_validators/`.
 Input validators can be specified as [VIVA](http://viva.vanb.org/)-files (with file ending `.viva`),
 [Checktestdata](https://github.com/DOMjudge/checktestdata)-file (with file ending `.ctd`),
-or as a program.
-Programs must either be written in C++ or Python 3,
-or must provide a `build` or `run` script as specified [above](#programs).
+or as a [program](#programs).
 
 All input validators provided will be run on every input file.
 Validation fails if any validator fails.


### PR DESCRIPTION
Also fix a bug: `c++` is the standard name for a C++ compiler; `cpp` is the C preprocessor.

Closes: #298