### PR TITLE
Output validator tweaks

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -970,52 +970,50 @@ If no floating-point tolerance has been set, floating-point tokens are treated j
 
 ### Invocation
 
-When invoked, the output validator will be passed at least three command line parameters and the output stream to validate on stdin.
-
-The validator should be possible to use as follows on the command line:
+The output validator must be invoked and must support being invoked as:
 ```sh
-<output_validator_program> input answer_file feedback_dir [additional_arguments] < team_output [ > team_input ]
+<output_validator_program> input_file answer_file feedback_dir [additional_arguments] < team_output [ > team_input ]
 ```
 
-The meaning of the parameters listed above are:
+The meanings of the parameters listed above are:
 
-- input:
+- input_file:
   a string specifying the name of the input data file that was used to test the program whose results are being validated.
 
 - answer_file:
   a string specifying the name of an arbitrary "answer file" which acts as input to the validator program.
   The answer file may, but is not necessarily required to, contain the "correct answer" for the problem.
-  For example, it might contain the output that was produced by a judge's solution for the problem when run with input file as input.
+  For example, it might contain the output that was produced by a judge's solution for the problem when run with `input_file` as input.
   Alternatively, the "answer file" might contain information, in arbitrary format, which instructs the validator in some way about how to accomplish its task.
 
 - feedback_dir:
   a string which specifies the name of a "feedback directory" in which the validator can produce "feedback files" in order to report additional information on the validation of the output file.
-  The feedback_dir must end with a path separator (typically '/' or '\\' depending on operating system),
-  so that simply appending a filename to feedback_dir gives the path to a file in the feedback directory.
+  The `feedback_dir` must end with a path separator (typically '/' or '\\' depending on operating system),
+  so that simply appending a filename to `feedback_dir` gives the path to a file in the feedback directory.
 
 - additional_arguments:
   in case `output_validator_args` are specified for the test case, these are passed as additional arguments to the validator on the command line.
 
 - team_output:
-  the output produced by the program being validated is given on the validator's standard input pipe.
+  the output produced by the program being validated is given on the validator's standard input.
 
 - team_input:
-  when running the validator in interactive mode everything written on the validator's standard output pipe is given to the program being validated.
-  Please note that when running interactive the program will only receive the output produced by the validator and will not have direct access to the input file.
+  when running the validator in interactive mode everything written on the validator's standard output is given to the program being validated.
+  Please note that when running interactively the program will only receive the output produced by the validator and will not have direct access to the input file.
 
-The two files pointed to by input and answer_file must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading.
-The directory pointed to by feedback_dir must also exist.
+The two files named by `input_file` and `answer_file` must exist (though they are allowed to be empty) and the validator program must be allowed to open them for reading.
+The directory named by `feedback_dir` must also exist and the validator program must be allowed to create and write to new and existing files there.
 
 ### Reporting a judgement
 
-A validator program is required to report its judgement by exiting with specific exit codes:
+A validator program must report its judgement by exiting with specific exit codes:
 
 - If the output is a correct output for the input file (i.e., the submission that produced the output is to be Accepted),
-  the validator exits with exit code 42.
+  the validator must exit with exit code 42.
 - If the output is incorrect (i.e., the submission that produced the output is to be judged as Wrong Answer),
-  the validator exits with exit code 43.
+  the validator must exit with exit code 43.
 
-Any other exit code (including 0\!) indicates that the validator did not operate properly,
+Any other exit code, **including 0**, indicates that the validator did not operate properly,
 and the judging system invoking the validator must take measures to report this to contest personnel.
 The purpose of these somewhat exotic exit codes is to avoid conflict with other exit codes that results when the validator crashes.
 For instance, if the validator is written in Java, any unhandled exception results in the program crashing with an exit code of 1,
@@ -1039,7 +1037,7 @@ A judging system that implements this format must support the `judgemessage.txt`
 (I.e., content of the `judgemessage.txt` file, if produced by the validator, must be provided by the judging system to a human judge examining the submission).
 Having the judging system support other files is optional.
 
-The validator may create one or more image files in the feedback directory with the name `teamimage.ext` and/or `judgeimage.ext`, where `ext` is one of: `png`, `jpg`, `jpeg`, or `svg`.
+The validator may create one or more image files in the feedback directory with the name `teamimage.<ext>` and/or `judgeimage.<ext>`, where `<ext>` is one of: `png`, `jpg`, `jpeg`, or `svg`.
 The [output visualizer](#output-visualizer) may modify or create these files as well,
 and the output validator may create files in the feedback directory containing metadata that helps the visualizer in this task.
 The intent is for the `teamimage` to be displayed to contestants and for `judgeimage` to be privileged information used as a debugging aid by contest judges, but the judge system may display or ignore these files as it sees fit.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1019,8 +1019,16 @@ Using the feedback directory is optional for a validator program, so if one just
 
 The validator is free to create different files in the feedback directory,
 in order to provide different kinds of information to the judging system, in a simple but organized way.
-For instance, there may be a `judgemessage.txt` file,
-the contents of which gives a message that is presented to a judge reviewing the current submission
+The following files have special meaning and are described below:
+
+- `nextpass.in` may be present in a [multi-pass](#multi-pass-validation) problem to indicate another pass follows
+- `score.txt` may be present in a [scoring](#scoring-test-cases) problem
+- `judgemessage.txt`may contain feedback for the judges
+- `teammessage.txt` may contain feedback for the team
+- `judgeimage.<ext>` may contain graphical feedback for the judges
+- `teamimage.<ext>` may contain graphical feedback for the team
+
+The contents of a `judgemessage.txt` gives a message that is presented to a judge reviewing the current submission
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
 Other examples of files that may be useful in some contexts (though not in the ICPC) are a `score.txt` file,
 giving the submission a score based on other factors than correctness,

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -926,25 +926,18 @@ it is recommended to include the input visualizer source code in the directory `
 
 ### Overview
 
-An output validator is a [program](#programs) that is given the output of a submitted program,
-together with the corresponding input file,
-and an answer file for the input,
-and then decides whether the output provided is a correct output for the given input file.
+Output validators are [programs](#programs) used to check that the output of a submission on a test case is correct.
+A trivial output validator could check that the submission output is equal to the answer file.
+The [default validator](#default-output-validator-specification) does essentially this,
+and supports some other commonly useful options.
 
-A validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
-The details of this invocation are described below.
-The validator program has two ways of reporting back the results of validating:
+For problems that require more complex checks, you can create a custom output validator
+and provide it as a program (as specified [above](#programs)) in the directory `output_validator/`.
+If no custom output validator is specified, the default validator is used.
 
-1.  The validator must give a judgement (see [Reporting a judgement](#reporting-a-judgement)).
-2.  The validator may give additional feedback,
-    e.g., an explanation of the judgement to humans (see [Reporting Additional Feedback](#reporting-additional-feedback)).
-
-A custom output validator is used if the problem requires more complicated output validation than what is provided by the default diff variant described below.
-It must be provided as a program (as specified [above](#programs)) in the directory `output_validator/`.
-It must adhere to the output validator specification described below.
-If no custom validator is provided, the default output validator will be used.
-
-The output validator will be run on the output for every test data file using the arguments specified for the test data group.
+The subsections below explain how a (default or custom) output validator must be
+[invoked](#invocation) and how it must [report a judgement](#reporting-a-judgement)
+and optionally [report additional feedback](#reporting-additional-feedback).
 
 ### Default Output Validator Specification
 


### PR DESCRIPTION
Small rewording and layout fixes, but also a few slightly bigger changes:

- require that the validator can write to new/existing files in feedback_dir
- replace explicit reference to program languages by reference to "programs" section
- list all possible files under `feedback_dir`