### PR TITLE
add valid_output

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -606,8 +606,8 @@ Each `tc.in` under `invalid_input` must be rejected by at least one input valida
 
 The test cases in `invalid_output` describe invalid outputs for non-interactive problems.
 They consist of three files.
-The input file `tc.in` must _pass_ input validation.
-The output file `tc.out` must _fail_ output validation for the given answer file `tc.ans`.
+The input file `tc.in`, which must contain valid input.
+The output file `tc.out` must fail output validation for the given answer file `tc.ans`.
 
 In particular, for an existing feedback directory `dir`,
 ```bash
@@ -615,7 +615,7 @@ In particular, for an existing feedback directory `dir`,
 <output_validator_program> tc.in tc.ans dir [arguments] < tc.out # MUST FAIL
 ```
 
-The directory `invalid_output` can be organized into a tree-like structure similar to `secret` and contain arguments in `testdata.yaml` files that are passed to the validators.
+The directory `invalid_output` must be organized into a tree-like structure similar to `secret` and may contain arguments in `testdata.yaml` files that are passed to the validators.
 
 ### Valid Output
 
@@ -623,8 +623,8 @@ The `data` directory may contain a directory of test cases that must pass valida
 Their goal is to ensure the integrity and quality of validation programs.
 The test cases in `valid_output` describe valid outputs for non-interactive problems.
 They consist of three files.
-The input file `tc.in` must _pass_ input validation.
-The output file `tc.out` must _pass_ output validation for the given answer file `tc.ans`.
+The input file `tc.in`, which must contain valid input.
+The output file `tc.out` must pass output validation for the given answer file `tc.ans`.
 
 In particular, for an existing feedback directory `dir`,
 ```bash
@@ -632,7 +632,7 @@ In particular, for an existing feedback directory `dir`,
 <output_validator_program> tc.in tc.ans dir [arguments] < tc.out # MUST PASS
 ```
 
-The directory `valid_output` can be organized into a tree-like structure similar to `secret` and contain arguments in `testdata.yaml` files that are passed to the validators.
+The directory `invalid_output` must be organized into a tree-like structure similar to `secret` and may contain arguments in `testdata.yaml` files that are passed to the validators.
 
 ### Samples
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -67,6 +67,7 @@ File or Folder         | Required? | Described In                               
 `data/secret/`         | Yes       | [Test Data](#test-data)                       | Secret test data
 `data/invalid_input/`  | No        | [Invalid Test Cases](#invalid-test-cases)     | Invalid test case input for testing input validation
 `data/invalid_output/` | No        | [Invalid Test Cases](#invalid-test-cases)     | Invalid test case output for testing output validation
+`data/valid_output/`   | No        | [Valid Output](#valid-output)                 | Valid test case output for testing output validation
 `generators/`          | No        | [Generators](#generators)                     | Scripts and documentation about how test cases were automatically generated
 `include/`             | No        | [Included Files](#included-files)             | Files appended to all submitted solutions
 `submissions/`         | Yes       | [Example Submissions](#example-submissions)   | Correct and incorrect judge solutions of the problem
@@ -614,7 +615,24 @@ In particular, for an existing feedback directory `dir`,
 <output_validator_program> tc.in tc.ans dir [arguments] < tc.out # MUST FAIL
 ```
 
-The directory `invalid` can be organized into a tree-like structure similar to `secret` and contain arguments in `testdata.yaml` files that are passed to the validators.
+The directory `invalid_output` can be organized into a tree-like structure similar to `secret` and contain arguments in `testdata.yaml` files that are passed to the validators.
+
+### Valid Output
+
+The `data` directory may contain a directory of test cases that must pass validation.
+Their goal is to ensure the integrity and quality of validation programs.
+The test cases in `valid_output` describe valid outputs for non-interactive problems.
+They consist of three files.
+The input file `tc.in` must _pass_ input validation.
+The output file `tc.out` must _pass_ output validation for the given answer file `tc.ans`.
+
+In particular, for an existing feedback directory `dir`,
+```bash
+<output_validator_program> tc.in tc.ans dir [arguments] < tc.ans # MUST PASS
+<output_validator_program> tc.in tc.ans dir [arguments] < tc.out # MUST PASS
+```
+
+The directory `valid_output` can be organized into a tree-like structure similar to `secret` and contain arguments in `testdata.yaml` files that are passed to the validators.
 
 ### Samples
 


### PR DESCRIPTION
Closes #355 

One think i noticed: 
> The test cases in `(in)valid_output` describe invalid outputs for **_non-interactive_** problems.

Maybe we should also exclude multi-pass problems?