### PR TITLE
Add flag to configure whether submissions can only read or both read …

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -155,7 +155,9 @@ Key                                               | Type                        
 [limits](#limits)                                 | Map with keys as defined below                | No        | See below
 [keywords](#keywords)                             | Sequence of strings                           | No        |
 [languages](#languages)                           | String or sequence of strings                 | No        | `all`
+[allow_file_writing](#allow-file-writing)         | Boolean                                       | No        | `false`
 [constants](#constants)                           | Map of strings to int, float, or string       | No        |
+
 
 ### Problem format version
 
@@ -374,6 +376,11 @@ List of programming languages codes from the [languages table](../appendix/langu
 If the value is not `all`, the problem may only be solved using the listed programming languages.
 
 File endings in parenthesis are not used for determining language.
+
+### Allow File Writing
+
+Flag for configuring whether submissions should have access to creating, editing and deleting files in their working directory.
+A value of `true` means submissions can read and write files, while the default value of `false` means submissions can only read from files.
 
 ### Constants
 

--- a/spec/changelog.md
+++ b/spec/changelog.md
@@ -33,6 +33,7 @@ sort: 1
 - Make `uuid` required in `problem.yaml`.
 - Add `/submissions/rejected` directory.
 - Clarify working directories for submissions and validators.
+- Add `allow_writing_files` to `problem.yaml`.
 
 ## Legacy version (changes since beginning 2021)
 


### PR DESCRIPTION
…and write to files in their working directory.

This makes changes based on the discussion in #333 
Closes #333 