### PR TITLE
Clarify rules for when `score.txt` and `score_multiplier.txt` can be used

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1041,6 +1041,7 @@ The following files have special meaning and are described below:
 
 - `nextpass.in` may be present in a [multi-pass](#multi-pass-validation) problem to indicate another pass follows
 - `score.txt` may be present in a [scoring](#scoring-test-cases) problem
+- `score_multiplier.txt` may be present in a [scoring](#scoring-test-cases) problem
 - `judgemessage.txt`may contain feedback for the judges
 - `teammessage.txt` may contain feedback for the team
 - `judgeimage.<ext>` may contain graphical feedback for the judges

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1129,17 +1129,17 @@ For pass-fail problems, the verdict of a submission is accepted if and only if e
 
 ### Scoring Problems
 
-In scoring problems, submissions are given a non-negative score instead of a verdict.
+For scoring problems, submissions are given a non-negative score instead of a verdict.
 The goal of each submission is to maximize this score.
 Only the `secret` group and its subgroups are scored.
 
 Given a submission, scores are determined for test cases, test groups, and the submission itself (which is the score of the `secret` group).
 The scoring behavior is configured for each test data group by the following arguments in the `scoring` dictionary of its `testdata.yaml`:
 
-Key           | Type           | Description
-------------- | -------------- | -----------
-`score`       | String         | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
-`aggregation` | `pass-fail`, `sum`, or `min` | How the score of the test data group is determined based on the scores of the subgroups and test cases. See below.
+Key           | Type                          | Description
+------------- | ----------------------------- | -----------
+`score`       | String                        | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
+`aggregation` | `pass-fail`, `sum`, or `min`  | How the score of the test data group is determined based on the scores of the subgroups and test cases. See below.
 `require-pass`| String or sequence of strings | Other test cases or groups whose test cases a submission must AC in order to receive a score for this test group. See below.
 
 The default value of `aggregation` is `sum` for the `secret` group and `pass-fail` for its subgroups.
@@ -1151,19 +1151,19 @@ The `secret` group's score may be any positive integer or `unbounded`.
 Subgroups of `secret` may only have `unbounded` maximum score if `secret` is unbounded.
 The default value of `score` for the `secret` group is 100.
 
-The default `score` for subgroups and test cases of groups with `sum` or `min` aggregation is inferred from the `score` value of that group and its children:
+The default `score` for subgroups and test cases of parent groups with `sum` or `min` aggregation is inferred from the `score` value of the parent group and its children:
 
-Group Maximum Score | Aggregation Type     | Default Maximum Score of Test Case / Subgroup
-------------------- | -------------------- | -------------------------------------
-`unbounded`         | `sum` or `min`       | `unbounded`
-bounded value `M`   | `sum`                | `(M - S)/(A + T)`
-bounded value `M`   | `min`                | `M`
+Parent Group Maximum Score | Aggregation Type     | Default Maximum Score of Test Case / Subgroup
+-------------------------- | -------------------- | -------------------------------------
+`unbounded`                | `sum` or `min`       | `unbounded`
+bounded value `M`          | `sum`                | `(M - S)/(A + T)`
+bounded value `M`          | `min`                | `M`
 
 where the group has `T` test cases, `A` subgroups without a provided `score`, and whose other subgroups have maximum scores that sum to `S`. 
 This formula evenly distributes a group's leftover maximum points to its test cases and subgroups with unspecified maximum score. 
 It is a judge error if `S > M` for a group with bounded maximum score and `sum` aggregation.
 
-### Scoring Test Cases
+#### Scoring Test Cases
 
 Only test cases in test case groups with `sum` or `min` aggregation receive a score. 
 
@@ -1183,7 +1183,7 @@ It is a judge error if:
 - an output validator produces a `score.txt` or `score_multiplier.txt` for a test case in a group with `pass-fail` aggregation;
 - an output valiadtor produces a `score.txt` or `score_multiplier.txt` with invalid contents.
 
-### Scoring Test Groups
+#### Scoring Test Groups
 
 The score of a test group is determined by its subgroups and test cases.
 If it has no subgroups or test cases, then its score is 0.
@@ -1200,7 +1200,7 @@ The submission score is the score of the `secret` group.
 
 It is a judge error if the score of any group or subgroup exceeds its maximum score.
 
-### Required Dependent Groups
+#### Required Dependent Groups
 
 A group may specify that it should only be scored if a submission is accepted for another test case or all test cases in another test data group and their dependencies.
 Otherwise, none of the group's test cases are judged and the group score is 0.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1185,7 +1185,7 @@ It is a judge error if:
 - an output validator produces a `score_multiplier.txt` for a test case with unbounded maximum score;
 - an output validator produces both a `score.txt` and a `score_multiplier.txt` for a test case;
 - an output validator produces a `score.txt` or `score_multiplier.txt` for a test case in a group with `pass-fail` aggregation;
-- an output valiadtor produces a `score.txt` or `score_multiplier.txt` with invalid contents.
+- an output validator produces a `score.txt` or `score_multiplier.txt` with invalid contents.
 
 #### Scoring Test Groups
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1172,14 +1172,18 @@ The score of a failed test case is always 0.
 A custom output validator may produce a `score.txt` or `score_multiplier.txt` file for an accepted test case:
 
 - for test cases with bounded maximum score, `score_multiplier.txt`, if produced, must contain a single floating-point number in the range `[0,1]`.
-  The score of the test case is this number _multiplied_ by the test case maximum score. If no `score_multiplier.txt` is produced, the test case score is its maximum score.
+  The score of the test case is this number _multiplied_ by the test case maximum score. 
+- for test cases with bounded maximum score, `score.txt`,  if produced, must contain a single single non-negative floating-point number.
+  The score of the test case is that number.
+- for test cases with bounded maximum score, if no `score_multiplier.txt` or `score.txt` is produced, the test case score is its maximum score.
 - for test cases with unbounded maximum score, `score.txt` must be produced and must contain a non-negative floating-point number.
   The score of the test case is that number.
 
 It is a judge error if:
 - an output validator accepts a test case in an unbounded group and does not produce a `score.txt`;
+- an output validator does not accept a test case, but does produce a `score.txt` or a `score_multiplier.txt`;
 - an output validator produces a `score_multiplier.txt` for a test case with unbounded maximum score;
-- an output validator produces a `score.txt` for a test case with bounded maximum score;
+- an output validator produces both a `score.txt` and a `score_multiplier.txt` for a test case;
 - an output validator produces a `score.txt` or `score_multiplier.txt` for a test case in a group with `pass-fail` aggregation;
 - an output valiadtor produces a `score.txt` or `score_multiplier.txt` with invalid contents.
 


### PR DESCRIPTION
Closes #356 

- some wording and formatting changes
- add `score_multiplier.txt` to list of known/defined additional feedback files
- it is allowed to use `score.txt` with bounded max
- not accepting but producing `score.txt` or `score_multiplier.txt` is not allowed
- it is not allowed to produce both `score.txt` and `score_multiplier.txt`
