### PR TITLE
Clean up the details of static validators

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1240,15 +1240,12 @@ A static validator may be provided under the `static_validator` directory, simil
 Each test group may define a static validation test case.
 It is an error to define static validation test cases without providing a static validator.
 A static validation test case is defined within a group's `testdata.yaml` file by specifying the key `static_validation`.
-If a map is specified, it may have two keys `args`, and in the case of scoring test groups, `score`.
-The key `args` maps to a string which represents the additional arguments passed to the static validator in this group's static validation test case.
-The key `score` maps to a float which represents both the maximum score achievable for the static validation test case and the default score assigned in case the static validator accepts the submission for that test case.
-The static validator can override this score by outputting a value to `score.txt` in the feedback directory, the same as an output validator.
-It can have the value of `false` meaning there is no static validation, `true` meaning that static validation is enabled with no score defined and no arguments.
-Aggregation is then applied to the test case in the same manner as other test cases.
-It is an error to assign a score in a `pass-fail` test group.
-It is an error to not assign a score in a `min` or `sum` test group.
-It is also an error to provide a static validator for `submit-answer` type problems.
+If a map is specified, its only allowed key is `args`, which maps to a string which represents the additional arguments passed to the static validator in this group's static validation test case.
+The `static_validation` key can also have the value of `false` meaning there is no static validation, or `true` meaning that static validation is enabled with no additional arguments.
+
+For scoring problems, a test group's static validation test case, if it exists, is treated as a normal test case for the purposes of maximum score inference; see [Scoring Problems](#scoring-problems) for details. 
+
+It is an error to provide a static validator for `submit-answer` type problems.
 
 ### Invocation
 
@@ -1262,7 +1259,7 @@ The validator should be possible to use as follows on the command line:
 The meaning of the parameters listed above are:
 
 - language:
-  a string specifying the code of the language of the submission as shown in the [languages table](languages.md).
+  a string specifying the code of the language of the submission as shown in the [languages table](languages.md). A static validator must handle all of the programming languages specified in the `languages` key of `problem.yaml`.
 
 - entry_point:
   a string specifying the entry point, that is a filename, class name, or some other identifier, which the static validator should know how to use depending on the language of the submission.
@@ -1274,3 +1271,5 @@ The meaning of the parameters listed above are:
 
 - additional_arguments:
   in case the static validation test case specifies additional args, these are passed as additional arguments to the validator on the command line.
+
+The static validator follows the semantics of an output validator for [reporting a judgment](#reporting-a-judgement) and [overriding the validation test case's default score](#scoring-test-cases).


### PR DESCRIPTION
Addresses https://github.com/Kattis/problem-package-format/issues/329

I've also cleaned up the scoring semantics of the static validator to align with the output validator: the default score is computed via maximum score inference from the parent test group, and this score can be overridden using `score.txt` or `score_multiplier.txt` as normal.