### PR TITLE
Problem Metadata: Use underscore instead of hyphen for embargo_until key

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1230,7 +1230,7 @@ Key           | Type                          | Description
 ------------- | ----------------------------- | -----------
 `score`       | String                        | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
 `aggregation` | `pass-fail`, `sum`, or `min`  | How the score of the test data group is determined based on the scores of the subgroups and test cases. See below.
-`require-pass`| String or sequence of strings | Other test cases or groups whose test cases a submission must AC in order to receive a score for this test group. See below.
+`require_pass`| String or sequence of strings | Other test cases or groups whose test cases a submission must AC in order to receive a score for this test group. See below.
 
 The default value of `aggregation` is `sum` for the `secret` group and `pass-fail` for its subgroups.
 
@@ -1299,7 +1299,7 @@ It is a judge error if the score of any group or subgroup exceeds its maximum sc
 A group may specify that it should only be scored if a submission is accepted for another test case or all test cases in another test data group and their dependencies.
 Otherwise, none of the group's test cases are judged and the group score is 0.
 
-The paths of these required test cases or groups, relative to the `data` folder, are listed under the `require-pass` key.
+The paths of these required test cases or groups, relative to the `data` folder, are listed under the `require_pass` key.
 The path of a group, relative to the `data/` folder, must come later lexicographically than the paths of all dependent test cases and groups.
 
 Each required group must be either `sample` or a subgroup of `secret` with `pass-fail` aggregation.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -152,7 +152,7 @@ Key                                               | Type                        
 [source](#source)                                 | String, a sequence, or a map as defined below | No        |
 [license](#license)                               | String                                        | No        | `unknown`
 [rights_owner](#license)                          | String                                        | See below | See below
-[embargo-until](#problem-publication-embargo)     | Date                                          | No        |
+[embargo_until](#problem-publication-embargo)     | Date                                          | No        |
 [limits](#limits)                                 | Map with keys as defined below                | No        | See below
 [keywords](#keywords)                             | Sequence of strings                           | No        |
 [languages](#languages)                           | String or non-empty sequence of strings       | No        | `all`
@@ -316,7 +316,7 @@ Values other than `unknown` or `public domain` require `rights_owner` to have a 
 
 ### Problem Publication Embargo
 
-The `embargo-until` key, if present, declares that the problem package should not be made publicly available (in problem archives, online judges, etc.) until a certain date and time.
+The `embargo_until` key, if present, declares that the problem package should not be made publicly available (in problem archives, online judges, etc.) until a certain date and time.
 The value of this key must be a calendar date, or date and time of day in UTC, in ISO-8601 extended format (`YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`).
 The time defaults to the start of the day in UTC.
 


### PR DESCRIPTION
No other keys use hyphens, so this makes all keys consistently use underscores. @thorehusfeldt already had this in his schema (https://github.com/thorehusfeldt/problem-package-schemas/blob/master/cue/problem.cue#L79).

(Actually, after scrolling through the spec again, I also found `require-pass` in Scoring Problems, so I updated that as well. :smile:)