### PR TITLE
Sync requirements for name key and statment filename

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -187,7 +187,7 @@ Value           | Incompatible with           | Comments
 
 The name of the problem in each language for which a problem statement exists.
 The `name` field is a map with the language codes as keys and the problem names as values.
-If there is only one langauge **and** that language is English, the `name` field can simplt be the problem name instead.
+If there is only one langauge **and** that language is English, the `name` field can simply be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.
 
 A deliberately complex and construed example:

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -199,7 +199,7 @@ name:
   fil: Kumusta mundo!
 ```
 
-The simplest example, which imples that the only provided language is `en`;
+The simplest example, which implies that the only provided language is `en`;
 ```yaml
 name: Hello World!
 ```

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -186,7 +186,7 @@ Value           | Incompatible with           | Comments
 ### Name
 
 The name of the problem in each language for which a problem statement exists.
-If there are statements in more than one language, the `name` field must be a map with the language codes as keys and the problem names as values.
+The `name` field must be a map with the language codes as keys and the problem names as values.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.
 
 A deliberately complex and construed example:
@@ -196,13 +196,6 @@ name:
   pt-BR: Olá mundo!
   pt-PT: Oi mundo!
   fil: Kumusta mundo!
-```
-
-If only a single problem statement exists, this may be a string with the name of the problem in that language (but a map with a single key is allowed).
-
-So the following example implies that only an English language problem statement exists:
-```yaml
-name: Hello World!
 ```
 
 ### UUID and version
@@ -412,7 +405,6 @@ The problem statement of the problem is provided in the directory `statement/`.
 This directory must contain one file per language, for at least one language, named `problem.<language>.<filetype>`,
 that contains the problem text itself, including input and output specifications.
 Here, `<language>` is a language code as described in [General Requirements](#general-requirements).
-Optionally, the language code can be left out; the default is then English (`en`).
 Filetype can be either `.tex` for LaTeX files, `.md` for Markdown, or `.pdf` for PDF.
 
 Please note that many kinds of transformations on the problem statements,

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -187,7 +187,7 @@ Value           | Incompatible with           | Comments
 
 The name of the problem in each language for which a problem statement exists.
 The `name` field is a map with the language codes as keys and the problem names as values.
-If there is only one langauge **and** that language is English, the `name` field can simply be the problem name instead.
+If there is only one language **and** that language is English, the `name` field can simply be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.
 
 A deliberately complex and construed example:

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -186,7 +186,8 @@ Value           | Incompatible with           | Comments
 ### Name
 
 The name of the problem in each language for which a problem statement exists.
-The `name` field must be a map with the language codes as keys and the problem names as values.
+The `name` field is a map with the language codes as keys and the problem names as values.
+If there is only one langauge **and** that language is English, the `name` field can simplt be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.
 
 A deliberately complex and construed example:
@@ -196,6 +197,11 @@ name:
   pt-BR: Olá mundo!
   pt-PT: Oi mundo!
   fil: Kumusta mundo!
+```
+
+The simplest example, which imples that the only provided language is `en`;
+```yaml
+name: Hello World!
 ```
 
 ### UUID and version


### PR DESCRIPTION
Closes #390: by doing nothing, which was the consensus.
Closes #389: by making language code *always* required for statement files, but defaulting to English in `problem.yaml`.