### PR TITLE
Add Webrick to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :jekyll_plugins do
   gem "jekyll-remote-theme"
   gem 'faraday', '< 1'
   gem 'liquid', '>= 4.0.1'
+  gem 'webrick'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.9.1)
 
 PLATFORMS
   ruby
@@ -257,6 +258,7 @@ DEPENDENCIES
   jekyll-commonmark-ghpages
   jekyll-remote-theme
   liquid (>= 4.0.1)
+  webrick
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
There are no official instructions on how to run this document locally. It's nice to be able to run it locally to check formatting. Personally, i use `bundle install` followed by `bundle exec jekyll serve`. When I do this, it seems that the gem `webrick` is missing. 

Am I doing something wrong? If so, maybe we should add instructions on how to run it properly. Otherwise, it would be nice to add it to the gemfile.