### PR TITLE
Specify where to get plaintext problem name

### DIFF
--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -240,7 +240,7 @@ Auxiliary files needed by the problem statement files must all be in `problem_st
 Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
 A LaTeX file may include the problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
-If a plaintext version of the problem name is required, the `name` from value from `problem.yaml` shall be used if present.
+If a plaintext version of the problem name is required, the `name` value from `problem.yaml` shall be used if present.
 If not, the name given in `\problemname` is displayed verbatim.
 
 The problem statements must only contain the actual problem statement, no sample data.

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -241,7 +241,7 @@ Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
 A LaTeX file may include the problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
 If a plaintext version of the problem name is required, the `name` value from `problem.yaml` shall be used if present.
-If not, the name given in `\problemname` is displayed verbatim.
+If not, the name given in `\problemname` is used verbatim.
 
 The problem statements must only contain the actual problem statement, no sample data.
 

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -239,7 +239,9 @@ Auxiliary files needed by the problem statement files must all be in `problem_st
 `problem.<language>.<filetype>` should reference auxiliary files as if the working directory is `problem_statement/`.
 Image file formats supported are `.png`, `.jpg`, `.jpeg`, and `.pdf`.
 
-A LaTeX file may include the Problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
+A LaTeX file may include the problem name using the LaTeX command `\problemname` in case LaTeX formatting of the title is wanted.
+If a plaintext version of the problem name is required, the `name` from value from `problem.yaml` shall be used if present.
+If not, the name given in `\problemname` is displayed verbatim.
 
 The problem statements must only contain the actual problem statement, no sample data.
 


### PR DESCRIPTION
Closes https://github.com/Kattis/problem-package-format/issues/398.

Should this also be added to `legacy-icpc`?