### PR TITLE
Change remaining instance of `testdata.yaml` to `test_group.yaml`

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -967,7 +967,7 @@ A static validator may be provided under the `static_validator` directory, simil
 
 Each test group may define a static validation test case.
 It is an error to define static validation test cases without providing a static validator.
-A static validation test case is defined within a group's `testdata.yaml` file by specifying the key `static_validation`.
+A static validation test case is defined within a group's `test_group.yaml` file by specifying the key `static_validation`.
 If a map is specified, its allowed key are:
 - `args`, which maps to a string which represents the additional arguments passed to the static validator in this group's static validation test case;
 - `score`, the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).


### PR DESCRIPTION
We missed one instance of `testdata.yaml` when renaming. Fixing.