### PR TITLE
Simplify result aggregation

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1307,7 +1307,6 @@ A custom output validator or static validator may produce a `score.txt` or `scor
   The score of the test case is this number _multiplied_ by the test case maximum score. 
 - for test cases with bounded maximum score, `score.txt`,  if produced, must contain a single single non-negative floating-point number.
   The score of the test case is that number. 
-  The number can be larger than the test case's inferred maximum score.
 - for test cases with bounded maximum score, if no `score_multiplier.txt` or `score.txt` is produced, the test case score is its maximum score.
 - for test cases with unbounded maximum score, `score.txt` must be produced and must contain a non-negative floating-point number.
   The score of the test case is that number.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -635,7 +635,7 @@ The format of `test_group.yaml` is as follows:
 
 Key                     | Type                                | Default                                 | Inheritance       | Comments
 ----------------------- | ----------------------------------- | --------------------------------------- | ----------------- | --------
-`scoring`               | Map                                 | [See Verdict/Score Aggregation](#verdictscore-aggregation)  | Not inherited  | Description of how the results of the group test cases and subgroups should be aggregated. This key is only permitted for the `secret` group and its subgroups.
+`scoring`               | Map                                 | [See Result Aggregation](#result-aggregation)  | Not inherited  | Description of how the results of the group test cases and subgroups should be aggregated. This key is only permitted for the `secret` group and its subgroups.
 `input_validator_args`  | Sequence of strings or map of strings to sequences of strings | empty string                      | Inherited      | See [Test Case Configuration](#test-case-configuration).
 `output_validator_args` | Sequence of strings                 | empty sequence                                              | Inherited      | See [Test Case Configuration](#test-case-configuration).
 `static_validation`     | Map or boolean                      | false                                                       | Not applicable | Configuration of static validation test data node. See [Static Validator](#static-validator)
@@ -1248,7 +1248,7 @@ It must not write to `score.txt`, `teammessage.txt`, or any other files in the f
 
 Compile or run-time errors in the visualizer are not judge errors. The return value and any data written by the visualizer to standard error or standard output are ignored.
 
-## Verdict/Score Aggregation
+## Result Aggregation
 
 ### Pass-Fail Problems
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1265,7 +1265,7 @@ The scoring behavior is configured for each test data group by the following arg
 
 Key           | Type                          | Description
 ------------- | ----------------------------- | -----------
-`score`       | String                        | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
+`score`       | Integer or `unbounded`        | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
 `aggregation` | `pass-fail`, `sum`, or `min`  | How the score of the test data group is determined based on the scores of the subgroups and test cases. See below.
 `require_pass`| String or sequence of strings | Other test cases or groups whose test cases a submission must AC in order to receive a score for this test group. See below.
 
@@ -1274,22 +1274,22 @@ The default value of `require_pass` is an empty sequence.
 
 #### Maximum Score Inference
 
-The `secret` group, and every subgroup and test case in a group with `sum` or `min` aggregation, have a maximum possible score.
+The `secret` group, every subgroup, and every test case in a group with `sum` or `min` aggregation, have a maximum possible score.
 The `secret` group's score may be any positive integer or `unbounded`.
 Subgroups of `secret` may only have `unbounded` maximum score if `secret` is unbounded.
 The default value of `score` for the `secret` group is 100.
 
-The default `score` for subgroups and test cases of parent groups with `sum` or `min` aggregation is inferred from the `score` value of the parent group and its children:
+The default `score` for test cases of parent groups with `sum` or `min` aggregation is inferred from the `score` value of the parent group and its children:
 
-Parent Group Maximum Score | Aggregation Type     | Default Maximum Score of Test Case / Subgroup
--------------------------- | -------------------- | -------------------------------------
+Parent Group Maximum Score | Aggregation Type     | Default Maximum Score of Test Case
+-------------------------- | -------------------- | ----------------------------------
 `unbounded`                | `sum` or `min`       | `unbounded`
-bounded value `M`          | `sum`                | `(M - S)/(A + B + T)`
+bounded value `M`          | `sum`                | `(M - S)/(B + T)`
 bounded value `M`          | `min`                | `M`
 
-where the group has `T` non-static-validation test cases, `A` subgroups without a provided `score`, `B` static validation test cases without a provided `score` (either 0 or 1), and whose other subgroups and static validation test cases have maximum scores that sum to `S`. 
-This formula evenly distributes a group's leftover maximum points to its test cases and subgroups with unspecified maximum score. 
-A group with bounded maximum score and `sum` aggregation must have `S <= M`.
+where the group has `T` non-static-validation test cases, `B` static validation test cases without a provided `score` (either 0 or 1), and whose subgroups and static validation test cases have maximum scores that sum to `S`. 
+This formula evenly distributes a group's leftover maximum points to its test cases and static test cases with unspecified maximum score. 
+A group with bounded maximum score and `sum` aggregation must have `S ≤ M`.
 
 #### Scoring Test Cases
 
@@ -1309,6 +1309,7 @@ A custom output validator or static validator may produce a `score.txt` or `scor
   The score of the test case is that number.
   
 It is a judge error if:
+
 - an output or static validator accepts a test case in an unbounded group and does not produce a `score.txt`;
 - an output or static validator does not accept a test case, but does produce a `score.txt` or a `score_multiplier.txt`;
 - an output or static validator produces a `score_multiplier.txt` for a test case with unbounded maximum score;
@@ -1321,7 +1322,7 @@ It is a judge error if:
 The score of a test group is determined by its subgroups and test cases.
 The score depends on the aggregation mode, which is either `pass-fail`, `sum`, or `min`.
 
-- If a group uses `pass-fail` aggregation, the group must have bounded maximum score and all subgroups must also use pass-fail aggregation.
+- If a group uses `pass-fail` aggregation, the group must have bounded maximum score and all subgroups must also use `pass-fail` aggregation.
 If the submission receives an accept verdict for all test cases in the group and its subgroups,
 the score of the group is equal to its maximum possible score.
 Otherwise the group score is 0.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1175,6 +1175,10 @@ The following files have special meaning and are described below:
 - `judgeimage.<ext>` may contain graphical feedback for the judges
 - `teamimage.<ext>` may contain graphical feedback for the team
 
+The validator may create a `score.txt`, a `score_multiplier.txt`, or neither, but it must not create both.
+This applies over all invocations.
+That is, if a validator ever creates a `score.txt`, then it must never create a `score_multiplier.txt`, and vice versa.
+
 The contents of a `judgemessage.txt` gives a message that is presented to a judge reviewing the current submission
 (typically used to help the judge verify why the submission was judged as incorrect, by specifying exactly what was wrong with its output).
 Other examples of files that may be useful in some contexts (though not in the ICPC) are a `score.txt` file,


### PR DESCRIPTION
- Renames "Verdict/Score Aggregation" section to "Result Aggregation".
- Score must be specified for all test data groups (#402)
- A validator can't use either `score.txt` or `score_multiplier.txt`, but not both (#402)
- A score > max score is an error (#408)

Closes #402 and #408
