### PR TITLE
Simplify test data groups

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -555,6 +555,41 @@ This means that for any two test cases, if their input, output validator argumen
 and the contents of their `.ans` files are equivalent, then the test cases are equivalent.
 The assumption of determinism means that a judge system could choose to reuse the result of a previous run, or to re-run the equivalent test case.
 
+### Test Data Configuration
+
+In `data/sample/`, `data/secret` and each [test data group](#test-data-groups), a YAML file `test_group.yaml` may be placed to specify how the result should be computed.
+
+The format of `test_group.yaml` is as follows:
+
+Key                     | Type                                | Default                                        | Comments
+----------------------- | ----------------------------------- | ---------------------------------------------- | --------
+`scoring`               | Map                                 | [See Result Aggregation](#result-aggregation)  | Description of how the results of the group test cases and subgroups should be aggregated. This key is only permitted for the `secret` group and its subgroups.
+`input_validator_args`  | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
+`output_validator_args` | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
+`static_validation`     | Map or boolean                      | false                                          | Configuration of static validation test data node. See [Static Validator](#static-validator)
+`full_feedback`         | Boolean                             | `false` in `secret`, `true` in `sample`        | See [Test Case Configuration](#test-case-configuration).
+`hint`                  | String                              |                                                | See [Test Case Configuration](#test-case-configuration).
+`description`           | String                              |                                                | See [Test Case Configuration](#test-case-configuration).
+
+### Test Data Groups
+
+The secret data may be sudivided into test data groups.
+A test data group is a subdirectory of `data/secret/` that also may contain a `test_group.yaml` configuration file.
+
+The test data for the problem can be organized into a tree-like structure rooted in the `data` folder.
+Each node of this tree is represented by a directory and referred to as a test data group.
+At the top level, the test data is divided into exactly two groups: `sample` and `secret`.
+The `secret` group may be further split into subgroups (each a subdirectory of `secret`).
+Each test data group (other than the root `data` group) may contain zero or more test cases (i.e., input-answer files).
+The `sample` directory may be omitted if a problem has no sample test cases.
+The `secret` directory must exist. 
+All test data groups other than `sample` must contain at least one of the following: a test case, a subgroup, or a static validation test case.
+
+Test cases and groups will be used in lexicographical order on file base name.
+If a specific order is desired, a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
+A subgroup must not have the same name as a test case in the same directory.
+For example, if the file `data/secret/huge.in` exists then the directory `data/secret/huge/` must not, and vice versa.
+
 ### Input
 
 Each test case can supply input via standard input, command-line arguments, and/or the file system.
@@ -609,40 +644,6 @@ An illustration provides a visualization of the associated test case, meant for 
 At most one illustration file may be provided per test case.
 The file must share the base name of the associated test case.
 The supported file extensions are `.png`, `.jpg`, `jpeg`, and `.svg`.
-
-
-### Test Data Groups
-
-The test data for the problem can be organized into a tree-like structure rooted in the `data` folder.
-Each node of this tree is represented by a directory and referred to as a test data group.
-At the top level, the test data is divided into exactly two groups: `sample` and `secret`.
-The `secret` group may be further split into subgroups (each a subdirectory of `secret`).
-Each test data group (other than the root `data` group) may contain zero or more test cases (i.e., input-answer files).
-The `sample` directory may be omitted if a problem has no sample test cases.
-The `secret` directory must exist. 
-All test data groups other than `sample` must contain at least one of the following: a test case, a subgroup, or a static validation test case.
-
-Test cases and groups will be used in lexicographical order on file base name.
-If a specific order is desired, a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
-A subgroup must not have the same name as a test case in the same directory.
-For example, if the file `data/secret/huge.in` exists then the directory `data/secret/huge/` must not, and vice versa.
-
-In each test data group, a YAML file `test_group.yaml` may be placed to specify how the result of the test data group should be computed.
-Some of the keys and their associated values will be inherited from the `test_group.yaml` in the closest ancestor group from the test case to the root `data` directory that has one.
-Others must be explicitly defined in the group's `test_group.yaml` file — otherwise they are set to the default values.
-If there is no `test_group.yaml` file in the root `data` group, one is implicitly added with the default values.
-
-The format of `test_group.yaml` is as follows:
-
-Key                     | Type                                | Default                                 | Inheritance       | Comments
------------------------ | ----------------------------------- | --------------------------------------- | ----------------- | --------
-`scoring`               | Map                                 | [See Result Aggregation](#result-aggregation)  | Not inherited  | Description of how the results of the group test cases and subgroups should be aggregated. This key is only permitted for the `secret` group and its subgroups.
-`input_validator_args`  | Sequence of strings or map of strings to sequences of strings | empty string                      | Inherited      | See [Test Case Configuration](#test-case-configuration).
-`output_validator_args` | Sequence of strings                 | empty sequence                                              | Inherited      | See [Test Case Configuration](#test-case-configuration).
-`static_validation`     | Map or boolean                      | false                                                       | Not applicable | Configuration of static validation test data node. See [Static Validator](#static-validator)
-`full_feedback`         | Boolean                             | `false` in `secret`, `true` in `sample`                     | Inherited      | See [Test Case Configuration](#test-case-configuration).
-`hint`                  | String                              |                                                             | Inherited      | See [Test Case Configuration](#test-case-configuration).
-`description`           | String                              |                                                             | Inherited      | See [Test Case Configuration](#test-case-configuration).
 
 ### Invalid Test Cases
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1296,7 +1296,7 @@ The score of a failed test case is always 0.
 A custom output validator or static validator may produce a `score.txt` or `score_multiplier.txt` file for an accepted test case:
 
 - for test cases with bounded maximum score, `score_multiplier.txt`, if produced, must contain a single floating-point number in the range `[0,1]`.
-  The score of the test case is this number _multiplied_ by the test case maximum score. 
+  The score of the test case is this number *multiplied* by the test case maximum score. 
 - for test cases with bounded maximum score, `score.txt`,  if produced, must contain a single single non-negative floating-point number.
   The score of the test case is that number. 
 - for test cases with bounded maximum score, if no `score_multiplier.txt` or `score.txt` is produced, the test case score is its maximum score.
@@ -1314,14 +1314,15 @@ It is a judge error if:
 
 #### Scoring Test Groups
 
-The score of a test group is determined by its subgroups and test cases.
+The score of `secret` is determined by its groups or test cases (it can only have one or the other).
+The score of a test group is determined by test cases.
 The score depends on the aggregation mode, which is either `pass-fail`, `sum`, or `min`.
 
-- If a group uses `pass-fail` aggregation, the group must have bounded maximum score and all subgroups must also use `pass-fail` aggregation.
-If the submission receives an accept verdict for all test cases in the group and its subgroups,
+- If a group uses `pass-fail` aggregation, the group must have bounded maximum score .
+If the submission receives an accepted verdict for all test cases or groups in the group,
 the score of the group is equal to its maximum possible score.
 Otherwise the group score is 0.
-- If a group uses `sum` aggregation, the group score is the sum of the scores of its test cases and subgroups.
+- If a group uses `sum` aggregation, the group score is the sum of the scores of its test cases or groups.
 - If a group uses `min` aggregation, then the group score is the minimum of these scores.
 
 The submission score is the score of the `secret` group. 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1009,7 +1009,10 @@ If a map is specified, its allowed key are:
 
 The `static_validation` key can also have the value of `false` meaning there is no static validation, or `true` meaning that static validation is enabled with no additional arguments and unspecified maximum score (to be determined by [maximum score inference](#maximum-score-inference)).
 
-It is an error to provide a static validator for `submit-answer` type problems, or to specify a `score` in a test group with `pass-fail` aggregation.
+It is an error to:
+- provide a static validator for `submit-answer` type problems,
+- specify a `score` in a test group with `pass-fail` aggregation or a problem that does not have the type `scoring`,
+- *not* specify a `score` in a test group that has `sum` or `min` aggregation.
 
 ### Invocation
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -568,8 +568,6 @@ Key                     | Type                                | Default         
 `output_validator_args` | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
 `static_validation`     | Map or boolean                      | false                                          | Configuration of static validation test data node. See [Static Validator](#static-validator)
 `full_feedback`         | Boolean                             | `false` in `secret`, `true` in `sample`        | See [Test Case Configuration](#test-case-configuration).
-`hint`                  | String                              |                                                | See [Test Case Configuration](#test-case-configuration).
-`description`           | String                              |                                                | See [Test Case Configuration](#test-case-configuration).
 
 ### Test Data Groups
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -568,13 +568,6 @@ The directory `test.files`, if it exists, contains input files available to the 
 All files in this directory must be copied into the submission's working directory after compiling, but before executing the submission, 
 possibly overwriting the compiled submission file or included data in the case of name conflicts.
 
-### Illustrations
-
-An illustration provides a visualization of the associated test case, meant for the judges.
-At most one illustration file may be provided per test case.
-The file must share the base name of the associated test case.
-The supported file extensions are `.png`, `.jpg`, `jpeg`, and `.svg`.
-
 ### Test Case Configuration
 
 One YAML file with additional configuration may be provided per test case.
@@ -609,6 +602,14 @@ For each test case:
 - A _hint_ provides feedback for solving a test case to, e.g., somebody whose submission didn't pass.
 - A _description_ conveys the purpose of a test case.
   It is an explanation of what aspect or edge case of the solution the input file is meant to test.
+
+### Illustrations
+
+An illustration provides a visualization of the associated test case, meant for the judges.
+At most one illustration file may be provided per test case.
+The file must share the base name of the associated test case.
+The supported file extensions are `.png`, `.jpg`, `jpeg`, and `.svg`.
+
 
 ### Test Data Groups
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1258,44 +1258,34 @@ Compile or run-time errors in the visualizer are not judge errors. The return va
 
 ### Pass-Fail Problems
 
-For pass-fail problems, the verdict of a submission is accepted if and only if every test case in both the `sample` group and the `secret` group and its subgroups is accepted.
+For pass-fail problems, the verdict of a submission is accepted if and only if every test case in `sample`, `secret`, and any [test data groups](#test-data-groups) are accepted.
 
 ### Scoring Problems
 
 For scoring problems, submissions are given a non-negative score instead of a verdict.
 The goal of each submission is to maximize this score.
-Only the `secret` group and its subgroups are scored.
 
-Given a submission, scores are determined for test cases, test groups, and the submission itself (which is the score of the `secret` group).
-The scoring behavior is configured for each test data group by the following arguments in the `scoring` dictionary of its `test_group.yaml`:
+Given a submission, scores are determined for test cases, [test data groups](#test-data-groups), and `secret` (which is the score of the submission itself).
+The scoring behavior is configured for `secret` and each test data group by the following arguments in the `scoring` dictionary of its `test_group.yaml`:
 
 Key           | Type                          | Description
 ------------- | ----------------------------- | -----------
 `score`       | Integer or `unbounded`        | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
-`aggregation` | `pass-fail`, `sum`, or `min`  | How the score of the test data group is determined based on the scores of the subgroups and test cases. See below.
+`aggregation` | `pass-fail`, `sum`, or `min`  | How the score is determined based on the scores of the contained groups or test cases. See below.
 `require_pass`| String or sequence of strings | Other test cases or groups whose test cases a submission must AC in order to receive a score for this test group. See below.
 
-The default value of `aggregation` is `sum` for the `secret` group and `pass-fail` for its subgroups. 
+The default value of `aggregation` is `sum` for `secret` and `pass-fail` for test data groups. 
 The default value of `require_pass` is an empty sequence.
 
-#### Maximum Score Inference
+For `secret`, all test data groups, and every test case in a group with `sum` or `min` aggregation, there is a maximum possible score.
+The default value of `score` for `secret` is 100.
+The default value of `score` for test data groups is `unbounded`.
+Test data groups may only have `unbounded` maximum score if `secret` is unbounded.
 
-The `secret` group, every subgroup, and every test case in a group with `sum` or `min` aggregation, have a maximum possible score.
-The `secret` group's score may be any positive integer or `unbounded`.
-Subgroups of `secret` may only have `unbounded` maximum score if `secret` is unbounded.
-The default value of `score` for the `secret` group is 100.
-
-The default `score` for test cases of parent groups with `sum` or `min` aggregation is inferred from the `score` value of the parent group and its children:
-
-Parent Group Maximum Score | Aggregation Type     | Default Maximum Score of Test Case
--------------------------- | -------------------- | ----------------------------------
-`unbounded`                | `sum` or `min`       | `unbounded`
-bounded value `M`          | `sum`                | `(M - S)/(B + T)`
-bounded value `M`          | `min`                | `M`
-
-where the group has `T` non-static-validation test cases, `B` static validation test cases without a provided `score` (either 0 or 1), and whose subgroups and static validation test cases have maximum scores that sum to `S`. 
-This formula evenly distributes a group's leftover maximum points to its test cases and static test cases with unspecified maximum score. 
-A group with bounded maximum score and `sum` aggregation must have `S ≤ M`.
+The maximum score of a test case in a group with `min` aggregation is `score`.
+The maximum score of a test case in a group with `sum` aggregation is `(score - static_score) / N`,
+where `static_score` is the score of the static validation test case if it exists, and 0 if not,
+and `N` is the number of test cases in the group.
 
 #### Scoring Test Cases
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -531,6 +531,9 @@ Exactly how the solution description is used is up to the user or tooling.
 The test data are provided in subdirectories of `data/`.
 The sample data in `data/sample/` and the secret data in `data/secret/`.
 
+The `sample` directory may be omitted if a problem has no sample test cases.
+The `secret` directory must exist, and contain either some test cases, or some [test data groups](#test-data-groups).
+
 All files and directories associated with a single test case have the same base name with varying extensions.
 Here, base name is defined to be the relative path from the `data` directory to the test case input file, without extensions.
 For example, the files `secret/test.in` and `secret/test.ans` are associated with the same test case that has the base name `secret/test`.
@@ -551,9 +554,12 @@ Extension                       | Described In                                  
 Judge systems may assume that the result of running a program on a test case is deterministic.
 For any two test cases, if the contents of their `.in` and `.files` directory are equivalent,
 as well as the `args` sequence in the `.yaml` file, then the input of the two test cases is equivalent.
-This means that for any two test cases, if their input, output validator arguments
-and the contents of their `.ans` files are equivalent, then the test cases are equivalent.
+This means that for any two test cases, if their input, output validator arguments and the contents of their `.ans` files are equivalent, then the test cases are equivalent.
 The assumption of determinism means that a judge system could choose to reuse the result of a previous run, or to re-run the equivalent test case.
+
+Test cases and [test data groups](#test-data-groups) will be used in lexicographical order on base name.
+It is good practice to use a numbered prefix such as `00`, `01`, `02`, `03`, and so on, to get the desired order of test cases, while keeping the file names descriptive.
+Remember that the numbered prefixes should be zer padded to the same length to get the expected lexicographical order.
 
 ### Test Data Configuration
 
@@ -572,21 +578,17 @@ Key                     | Type                                | Default         
 ### Test Data Groups
 
 The secret data may be sudivided into test data groups.
-A test data group is a subdirectory of `data/secret/` that also may contain a `test_group.yaml` configuration file.
+A test data group is a subdirectory of `data/secret/` and may contain a `test_group.yaml` configuration file.
+`data/secret` can only have test data groups *or* test cases, never both.
+That is, if there are any directories under `data/secret/` there must not be any `.in` files directly in `data/secret/` and vice versa.
 
-The test data for the problem can be organized into a tree-like structure rooted in the `data` folder.
-Each node of this tree is represented by a directory and referred to as a test data group.
-At the top level, the test data is divided into exactly two groups: `sample` and `secret`.
-The `secret` group may be further split into subgroups (each a subdirectory of `secret`).
-Each test data group (other than the root `data` group) may contain zero or more test cases (i.e., input-answer files).
-The `sample` directory may be omitted if a problem has no sample test cases.
-The `secret` directory must exist. 
-All test data groups other than `sample` must contain at least one of the following: a test case, a subgroup, or a static validation test case.
+The test groups themselves can contain directories, but not further groups.
+This means that there are no `test_group.yaml` furter down in the directory hierarchy.
 
-Test cases and groups will be used in lexicographical order on file base name.
-If a specific order is desired, a numbered prefix such as `00`, `01`, `02`, `03`, and so on, can be used.
-A subgroup must not have the same name as a test case in the same directory.
-For example, if the file `data/secret/huge.in` exists then the directory `data/secret/huge/` must not, and vice versa.
+A directory must not have the same name as a test case in the same directory.
+For example, if the file `data/secret/group1/huge.in` exists then the directory `data/secret/group1/huge/` must not, and vice versa.
+
+Each test data group must contain at least one test case, or a static validation test case.
 
 ### Input
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -559,7 +559,7 @@ The assumption of determinism means that a judge system could choose to reuse th
 
 Test cases and [test data groups](#test-data-groups) will be used in lexicographical order on base name.
 It is good practice to use a numbered prefix such as `00`, `01`, `02`, `03`, and so on, to get the desired order of test cases, while keeping the file names descriptive.
-Remember that the numbered prefixes should be zer padded to the same length to get the expected lexicographical order.
+Remember that the numbered prefixes should be zero padded to the same length to get the expected lexicographical order.
 
 ### Test Data Configuration
 
@@ -578,7 +578,7 @@ Key                     | Type                                | Default         
 ### Test Data Groups
 
 The secret data may be sudivided into test data groups.
-A test data group is a subdirectory of `data/secret/` and may contain a `test_group.yaml` configuration file.
+Every subdirectory of `data/secret/` is a test data group and may contain a `test_group.yaml` configuration file.
 `data/secret` can only have test data groups *or* test cases, never both.
 That is, if there are any directories under `data/secret/` there must not be any `.in` files directly in `data/secret/` and vice versa.
 
@@ -1321,7 +1321,7 @@ The score of `secret` is determined by its groups or test cases (it can only hav
 The score of a test group is determined by test cases.
 The score depends on the aggregation mode, which is either `pass-fail`, `sum`, or `min`.
 
-- If a group uses `pass-fail` aggregation, the group must have bounded maximum score .
+- If a group uses `pass-fail` aggregation, the group must have bounded maximum score.
 If the submission receives an accepted verdict for all test cases or groups in the group,
 the score of the group is equal to its maximum possible score.
 Otherwise the group score is 0.


### PR DESCRIPTION
This PR does the following:
- groups can only contain groups *or* cases, not both (#410)
- there is only one level of groups below `/secret` (#410)
- `test_group.yaml` is not inherited
- remove `hint` and `description` from `test_group.yaml`
- require static cases to always specify `score`
- groups must specify `score`, i.e. no max score inference (#414)

Some oddities due to these changes:
- `test_group.yaml` is not really a good name anymore.
- you can organize you test cases in directories freely in groups, but not in `/secret` (because they become groups)
- the terminology use for groups is a little bit inconsistent right now. Specifically, is `/secret` a group or only the groups *under* `/secret`, currently the usage is mixed.

I think the oddities can (and should) be fixed in follow-ups, if we feel that the large strokes of this is the right way to go.

Closes: #410 
Closes: #414 