### PR TITLE
embargo_until timezone 'Z' constant clarification.

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -332,8 +332,8 @@ Otherwise, if a `source` is specified, the legal entity owning the rights associ
 ### Problem Publication Embargo
 
 The `embargo_until` key, if present, declares that the problem package should not be made publicly available (in problem archives, online judges, etc.) until a certain date and time.
-The value of this key must be a calendar date, or date and time of day in UTC, in ISO-8601 extended format (`YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`).
-The time defaults to the start of the day in UTC.
+The value of this key must be a calendar date, or date and time of day in **UTC**, in ISO-8601 extended format (`YYYY-MM-DD` or `YYYY-MM-DD'T'hh:mm:ss'Z'`, where T and Z are constants not to be changed).
+The time of day defaults to the start of the day in UTC if not specified.
 
 ### Limits
 


### PR DESCRIPTION
Made specification regarding timezones for embargo_until in 2023-07 clearer.
Issue: https://github.com/Kattis/problem-package-format/issues/420