### PR TITLE
Fix outdated link to Languages table

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -777,7 +777,7 @@ judge systems are not responsible for executing the provided generators and all 
 
 Files that should be included with all submissions are provided in one non-empty directory per supported language.
 Files that should be included for all languages are placed in the non-empty directory `include/default/`.
-Files that should be included for a specific language, overriding the default, are provided in the non-empty directory `include/<language>/`, where `<language>` is a language code as given in the [languages table](#languages).
+Files that should be included for a specific language, overriding the default, are provided in the non-empty directory `include/<language>/`, where `<language>` is a language code as given in the [languages table](../appendix/languages.md).
 
 The files should be copied from a language directory based on the language of the submission,
 to the submission files before compiling, but after checking whether the submission exceeds the code limit,


### PR DESCRIPTION
The link to the Languages table in the Included Files section hadn't been updated, even though the languages table has been moved to an appendix.