### PR TITLE
Remove kramdown syntax

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -961,7 +961,7 @@ or as a program (as specified [above](#programs)).
 All input validators provided will be run on every input file.
 Validation fails if any validator fails.
 
-### Invocation {#input-validators-invocation}
+### Invocation
 
 An input validator program must be an application (executable or interpreted) capable of being invoked with a command line call.
 
@@ -1017,7 +1017,7 @@ It is an error to:
 - specify a `score` in a test group with `pass-fail` aggregation or a problem that does not have the type `scoring`,
 - *not* specify a `score` in a test group that has `sum` or `min` aggregation.
 
-### Invocation {#static-validator-invocation}
+### Invocation
 
 When invoked, the static validator will be passed at least three command line parameters.
 


### PR DESCRIPTION
Undo earlier "fix" that broke things (because we don't use kramdown)