### PR TITLE
2023-07-draft: Add `args` to test_group.yaml

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -618,19 +618,19 @@ Any unknown keys should be treated as an error.
 Key                     | Type                | Default
 ----------------------- | ------------------- | -------
 `args`                  | Sequence of strings | Inherited from [`test_group.yaml`](#test-data-groups), which defaults to empty sequence
-`output_validator_args` | Sequence of strings | Inherited from [`test_group.yaml`](#test-data-groups), which defaults to empty sequence
 `input_validator_args`  | Sequence of strings or map of strings to sequences of strings | Inherited from [`test_group.yaml`](#test-data-groups), which defaults to empty sequence
+`output_validator_args` | Sequence of strings | Inherited from [`test_group.yaml`](#test-data-groups), which defaults to empty sequence
 `full_feedback`         | Boolean             | Inherited from [`test_group.yaml`](#test-data-groups), which defaults to `false` in `secret` and `true` in `sample`
 `hint`                  | String              | 
 `description`           | String              | 
 
 For each test case:
 - `args` defines arguments passed to the submission for this test case.
-- `output_validator_args` defines arguments passed to the output validator for the test case.
 - `input_validator_args` defines arguments passed to each input validator for the test case.
   If a sequence of strings, then those are the arguments that will be passed to each input validator for this case.
   If a map, then each key is the name of the input validator and the value is the arguments to pass to that input validator for the test case.
   Validators not present in the map are run without any arguments.
+- `output_validator_args` defines arguments passed to the output validator for the test case.
 - When `full_feedback` is `true`, somebody whose submission didn't pass case should be shown:
     - the given input,
     - the produced output (stdout),


### PR DESCRIPTION
In section Test Case Configuration, it is mentioned that `args` is inherited from `test_group.yaml`, but it was not yet specified there.