### PR TITLE
Clearer \problemname and specify that `name` from `problem.yaml` is displayed verbatim

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -455,12 +455,12 @@ It is the judging system's responsibility to wrap this text in an appropriate La
 The LaTeX class shall provide the convenience environments `Input`, `Output`, and `Interaction` for delineating sections of the problem statement.
 It shall also provide the following commands:
 
-- `\problemname{name}`, which should typically be the first line of the problem statement and places the problem name into the problem statement header.
+- `\problemname{name}`, which should typically be the first line of the problem statement and sets the problem name in the statement header.
   The argument `name` is optional.
   If it is missing, the `name` value from `problem.yaml` matching the problem statement's language is used.
   If it is present, it is used instead, and must be a LaTeX-formatted version of the `name` value from `problem.yaml` matching the problem statement's language.
-  In some cases, the problem name might contain math formulas or other text that should be typeset specially.
-  In this case, the `\problemname{name}` command should be used instead and overrides the name in the header with `name`, a LaTeX-formatted version of the problem name.
+  In particular, this should be used if the problem name contains math formulas or other text that should be typeset using LaTeX. The field `name` from `problem.yaml`
+  must never contain LaTeX, as it will be used in places where the judge system does not support LaTeX rendering.
 - `\illustration{width}{filename}{caption}`, a convenience command for adding a figure to the problem statement.
   `width` is a floating-point argument specifying the width of the figure as a fraction of the total width of the problem statement;
   `filename` is the image to display, and `caption`, the text to include below the figure.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -191,7 +191,7 @@ Value           | Incompatible with           | Comments
 ### Name
 
 The name of the problem in each language for which a problem statement exists.
-It must not contain any LaTeX formatting, as it will always be used in places where judge system does not support rendering LaTeX.
+Each name must not contain any LaTeX formatting, as it will be used in places where judge system does not support LaTeX rendering.
 The `name` field is a map with the language codes as keys and the problem names as values.
 If there is only one language **and** that language is English, the `name` field can simply be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.
@@ -460,8 +460,8 @@ It shall also provide the following commands:
   The argument `name` is optional.
   If it is missing, the `name` value from `problem.yaml` matching the problem statement's language is used.
   If it is present, it is used instead, and must be a LaTeX-formatted version of the `name` value from `problem.yaml` matching the problem statement's language.
-  In particular, this should be used if the problem name contains math formulas or other text that should be typeset using LaTeX. The field `name` from `problem.yaml`
-  must never contain LaTeX, as it will be used in places where the judge system does not support LaTeX rendering.
+  In particular, this should be used if the problem name contains math formulas or other text that should be typeset using LaTeX. Also note that the field `name`
+  from `problem.yaml` must never contain LaTeX, as it will be used in places where the judge system does not support LaTeX rendering.
 - `\illustration{width}{filename}{caption}`, a convenience command for adding a figure to the problem statement.
   `width` is a floating-point argument specifying the width of the figure as a fraction of the total width of the problem statement;
   `filename` is the image to display, and `caption`, the text to include below the figure.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -191,7 +191,7 @@ Value           | Incompatible with           | Comments
 ### Name
 
 The name of the problem in each language for which a problem statement exists.
-Each name must not contain any LaTeX formatting, as it will be used in places where judge system does not support LaTeX rendering.
+Each name should not contain any LaTeX formatting, as it will be used in places where judge system does not support LaTeX rendering.
 The `name` field is a map with the language codes as keys and the problem names as values.
 If there is only one language **and** that language is English, the `name` field can simply be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -191,6 +191,7 @@ Value           | Incompatible with           | Comments
 ### Name
 
 The name of the problem in each language for which a problem statement exists.
+It must not contain any LaTeX formatting, as it will always be used in places where judge system does not support rendering LaTeX.
 The `name` field is a map with the language codes as keys and the problem names as values.
 If there is only one language **and** that language is English, the `name` field can simply be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.


### PR DESCRIPTION
The previous version of the `\problemname` section was very repetitive. I've tried to make it clearer.

I have also added that `name` from `problem.yaml` should always be provided without LaTeX formatting. Most judge systems will display the problem name in at least one place where it does not support LaTeX rendering, so I think that adding this meaning is very useful for both online judge developers and problem authors. 

This also implies that markdown statements cannot have statements with LaTeX formatting in them. I personally think that this is fine; our usage of markdown is intended to weaker and simpler than LaTeX.