### PR TITLE
Cleanup scoring

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1012,7 +1012,7 @@ Each test group may define a static validation test case.
 It is an error to define static validation test cases without providing a static validator.
 A static validation test case is defined within a group's `test_group.yaml` file by specifying the key `static_validation_score`.
 
-If `static_validation_score` is specified as an non-negaive integer is it the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).
+If `static_validation_score` is specified as a non-negative integer, then it is the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).
 If it is specified as `pass-fail` then the test group it is part of must have `pass-fail` aggregation, or the problem be of type `pas-fail`.
 If `static_validator_args` is given it defines arguments passed to the static validator.
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -574,11 +574,12 @@ Key                     | Type                                | Default         
 ----------------------- | ----------------------------------- | ---------------------------------------------- | --------
 `max_score`             | Integer or `unbounded`              | 100 in `secret`, otherwise `unbounded`         | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`. This key is only permitted for the `secret` group and its subgroups.
 `score_aggregation`     | `pass-fail`, `sum`, or `min`        | `sum` in `secret`, otherwise `pass-fail`       | How the score is determined based on the scores of the contained groups or test cases. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
+`static_validation_score` | Integer or `pass-fail`            |                                                | The maximum score of the static validation test case, or `pass-fail`. See [Static Validator](#static-validator).
 `require_pass`          | String or sequence of strings       | empty sequence                                 | Other test data groups whose test cases a submission must pass in order to receive a score for this test group. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
 `args`                  | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
 `input_validator_args`  | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
 `output_validator_args` | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
-`static_validation`     | Map or boolean                      | false                                          | Configuration of static validation test data node. See [Static Validator](#static-validator)
+`static_validator_args` | Sequence of strings                 | empty sequence                                 | See [Static Validator](#static-validator). 
 `full_feedback`         | Boolean                             | `false` in `secret`, `true` in `sample`        | See [Test Case Configuration](#test-case-configuration).
 
 ### Test Data Groups
@@ -1009,17 +1010,16 @@ A static validator may be provided under the `static_validator` directory, simil
 
 Each test group may define a static validation test case.
 It is an error to define static validation test cases without providing a static validator.
-A static validation test case is defined within a group's `test_group.yaml` file by specifying the key `static_validation`.
-If a map is specified, its allowed keys are:
-- `args`, which maps to a string which represents the additional arguments passed to the static validator in this group's static validation test case;
-- `score`, the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).
+A static validation test case is defined within a group's `test_group.yaml` file by specifying the key `static_validation_score`.
 
-The `static_validation` key can also have the value of `false` meaning there is no static validation, or `true` meaning that static validation is enabled with no additional arguments and unspecified maximum score (to be determined by [maximum score inference](#maximum-score-inference)).
+If `static_validation_score` is specified as an non-negaive integer is it the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).
+If it is specified as `pass-fail` then the test group it is part of must have `pass-fail` aggregation, or the problem be of type `pas-fail`.
+If `static_validator_args` is given it defines arguments passed to the static validator.
 
 It is an error to:
 - provide a static validator for `submit-answer` type problems,
-- specify a `score` in a test group with `pass-fail` aggregation or a problem that does not have the type `scoring`,
-- *not* specify a `score` in a test group that has `sum` or `min` aggregation.
+- specify a `static_validation_score` in a test group with `pass-fail` aggregation or a problem that does not have the type `scoring`,
+- specify a `static_validator_args` without specifying `static_validation_score`.
 
 ### Invocation
 
@@ -1287,8 +1287,8 @@ The default value of `max_score` for test data groups is `unbounded`.
 Test data groups may only have `unbounded` maximum score if `secret` is unbounded.
 
 The maximum score of a test case in a group with `min` aggregation is `score`.
-The maximum score of a test case in a group with `sum` aggregation is `(max_score - static_score) / N`,
-where `static_score` is the score of the static validation test case if it exists, and 0 if not,
+The maximum score of a test case in a group with `sum` aggregation is `(max_score - static_validation_score) / N`,
+where `static_validation_score` is the score of the static validation test case if it exists, and 0 if not,
 and `N` is the number of test cases in the group.
 
 #### Scoring Test Cases

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -580,7 +580,7 @@ Key                       | Type                                | Default       
 `input_validator_args`    | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
 `output_validator_args`   | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
 `static_validator_args`   | Sequence of strings                 | empty sequence                                 | See [Static Validator](#static-validator). 
-`full_feedback`           | Boolean                             | `false` in `secret`, `true` in `sample`        | See [Test Case Configuration](#test-case-configuration).
+`full_feedback`           | Boolean                             | `true` in `sample`, otherwise `false`          | See [Test Case Configuration](#test-case-configuration).
 
 ### Test Data Groups
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1014,7 +1014,7 @@ A static validation test case is defined within a group's `test_group.yaml` file
 
 If `static_validation_score` is specified as a non-negative integer, then it is the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).
 If it is specified as `pass-fail`, then the test group it is part of must have `pass-fail` aggregation, or the problem must be of type `pass-fail`.
-If `static_validator_args` is given it defines arguments passed to the static validator.
+If `static_validator_args` is given, then it defines arguments passed to the static validator.
 
 It is an error to:
 - provide a static validator for `submit-answer` type problems,

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -535,7 +535,7 @@ The test data are provided in subdirectories of `data/`.
 The sample data in `data/sample/` and the secret data in `data/secret/`.
 
 The `sample` directory may be omitted if a problem has no sample test cases.
-The `secret` directory must exist, and contain either some test cases, or some [test data groups](#test-data-groups).
+The `secret` directory must exist, and contain either some test cases, or some [test data groups](#test-data-groups), but not both.
 
 All files and directories associated with a single test case have the same base name with varying extensions.
 Here, base name is defined to be the relative path from the `data` directory to the test case input file, without extensions.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1013,7 +1013,7 @@ It is an error to define static validation test cases without providing a static
 A static validation test case is defined within a group's `test_group.yaml` file by specifying the key `static_validation_score`.
 
 If `static_validation_score` is specified as a non-negative integer, then it is the maximum score of the static validation test case (see [Scoring Problems](#scoring-problems) for details).
-If it is specified as `pass-fail` then the test group it is part of must have `pass-fail` aggregation, or the problem be of type `pas-fail`.
+If it is specified as `pass-fail`, then the test group it is part of must have `pass-fail` aggregation, or the problem must be of type `pass-fail`.
 If `static_validator_args` is given it defines arguments passed to the static validator.
 
 It is an error to:

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1319,7 +1319,7 @@ It is a judge error if:
 #### Scoring Test Groups
 
 The score of `secret` is determined by its groups or test cases (it can only have one or the other).
-The score of a test group is determined by test cases.
+The score of a test group is determined by its test cases.
 The score depends on the aggregation mode, which is either `pass-fail`, `sum`, or `min`.
 
 - If a group uses `pass-fail` aggregation, the group must have bounded maximum score.

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -570,17 +570,17 @@ In `data/sample/`, `data/secret` and each [test data group](#test-data-groups), 
 
 The format of `test_group.yaml` is as follows:
 
-Key                     | Type                                | Default                                        | Comments
------------------------ | ----------------------------------- | ---------------------------------------------- | --------
-`max_score`             | Integer or `unbounded`              | 100 in `secret`, otherwise `unbounded`         | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`. This key is only permitted for the `secret` group and its subgroups.
-`score_aggregation`     | `pass-fail`, `sum`, or `min`        | `sum` in `secret`, otherwise `pass-fail`       | How the score is determined based on the scores of the contained groups or test cases. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
+Key                       | Type                                | Default                                        | Comments
+------------------------- | ----------------------------------- | ---------------------------------------------- | --------
+`max_score`               | Integer or `unbounded`              | 100 in `secret`, otherwise `unbounded`         | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`. This key is only permitted for the `secret` group and its subgroups.
+`score_aggregation`       | `pass-fail`, `sum`, or `min`        | `sum` in `secret`, otherwise `pass-fail`       | How the score is determined based on the scores of the contained groups or test cases. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
 `static_validation_score` | Integer or `pass-fail`            |                                                | The maximum score of the static validation test case, or `pass-fail`. See [Static Validator](#static-validator).
-`require_pass`          | String or sequence of strings       | empty sequence                                 | Other test data groups whose test cases a submission must pass in order to receive a score for this test group. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
-`args`                  | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
-`input_validator_args`  | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
-`output_validator_args` | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
-`static_validator_args` | Sequence of strings                 | empty sequence                                 | See [Static Validator](#static-validator). 
-`full_feedback`         | Boolean                             | `false` in `secret`, `true` in `sample`        | See [Test Case Configuration](#test-case-configuration).
+`require_pass`            | String or sequence of strings       | empty sequence                                 | Other test data groups whose test cases a submission must pass in order to receive a score for this test group. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
+`args`                    | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
+`input_validator_args`    | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
+`output_validator_args`   | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
+`static_validator_args`   | Sequence of strings                 | empty sequence                                 | See [Static Validator](#static-validator). 
+`full_feedback`           | Boolean                             | `false` in `secret`, `true` in `sample`        | See [Test Case Configuration](#test-case-configuration).
 
 ### Test Data Groups
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -577,7 +577,7 @@ Key                       | Type                                | Default       
 `static_validation_score` | Integer or `pass-fail`            |                                                | The maximum score of the static validation test case, or `pass-fail`. See [Static Validator](#static-validator).
 `require_pass`            | String or sequence of strings       | empty sequence                                 | Other test data groups whose test cases a submission must pass in order to receive a score for this test group. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
 `args`                    | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
-`input_validator_args`    | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
+`input_validator_args`    | Sequence of strings or map of strings to sequences of strings | empty sequence       | See [Test Case Configuration](#test-case-configuration).
 `output_validator_args`   | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
 `static_validator_args`   | Sequence of strings                 | empty sequence                                 | See [Static Validator](#static-validator). 
 `full_feedback`           | Boolean                             | `true` in `sample`, otherwise `false`          | See [Test Case Configuration](#test-case-configuration).

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1019,7 +1019,7 @@ If `static_validator_args` is given, then it defines arguments passed to the sta
 It is an error to:
 - provide a static validator for `submit-answer` type problems,
 - specify a `static_validation_score` in a test group with `pass-fail` aggregation or a problem that does not have the type `scoring`,
-- specify a `static_validator_args` without specifying `static_validation_score`.
+- specify `static_validator_args` without specifying `static_validation_score`.
 
 ### Invocation
 

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -572,7 +572,9 @@ The format of `test_group.yaml` is as follows:
 
 Key                     | Type                                | Default                                        | Comments
 ----------------------- | ----------------------------------- | ---------------------------------------------- | --------
-`scoring`               | Map                                 | [See Result Aggregation](#result-aggregation)  | Description of how the results of the group test cases and subgroups should be aggregated. This key is only permitted for the `secret` group and its subgroups.
+`max_score`             | Integer or `unbounded`              | 100 in `secret`, otherwise `unbounded`         | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`. This key is only permitted for the `secret` group and its subgroups.
+`score_aggregation`     | `pass-fail`, `sum`, or `min`        | `sum` in `secret`, otherwise `pass-fail`       | How the score is determined based on the scores of the contained groups or test cases. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
+`require_pass`          | String or sequence of strings       | empty sequence                                 | Other test data groups whose test cases a submission must pass in order to receive a score for this test group. [See Result Aggregation](#result-aggregation). This key is only permitted for the `secret` group and its subgroups.
 `args`                  | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
 `input_validator_args`  | Sequence of strings or map of strings to sequences of strings | empty string         | See [Test Case Configuration](#test-case-configuration).
 `output_validator_args` | Sequence of strings                 | empty sequence                                 | See [Test Case Configuration](#test-case-configuration).
@@ -1274,24 +1276,18 @@ For scoring problems, submissions are given a non-negative score instead of a ve
 The goal of each submission is to maximize this score.
 
 Given a submission, scores are determined for test cases, [test data groups](#test-data-groups), and `secret` (which is the score of the submission itself).
-The scoring behavior is configured for `secret` and each test data group by the following arguments in the `scoring` dictionary of its `test_group.yaml`:
+The scoring behavior is configured for `secret` and each test data group by `max_score`, `score_aggregation`, and `require_pass` in its [`test_group.yaml`](#test-data-configuration).
 
-Key           | Type                          | Description
-------------- | ----------------------------- | -----------
-`score`       | Integer or `unbounded`        | The maximum possible score of the test data group. Must be a non-negative integer or `unbounded`.
-`aggregation` | `pass-fail`, `sum`, or `min`  | How the score is determined based on the scores of the contained groups or test cases. See below.
-`require_pass`| String or sequence of strings | Other test data groups whose test cases a submission must pass in order to receive a score for this test group. See below.
-
-The default value of `aggregation` is `sum` for `secret` and `pass-fail` for test data groups. 
+The default value of `score_aggregation` is `sum` for `secret` and `pass-fail` for test data groups. 
 The default value of `require_pass` is an empty sequence.
 
 For `secret`, all test data groups, and every test case in a group with `sum` or `min` aggregation, there is a maximum possible score.
-The default value of `score` for `secret` is 100.
-The default value of `score` for test data groups is `unbounded`.
+The default value of `max_score` for `secret` is 100.
+The default value of `max_score` for test data groups is `unbounded`.
 Test data groups may only have `unbounded` maximum score if `secret` is unbounded.
 
 The maximum score of a test case in a group with `min` aggregation is `score`.
-The maximum score of a test case in a group with `sum` aggregation is `(score - static_score) / N`,
+The maximum score of a test case in a group with `sum` aggregation is `(max_score - static_score) / N`,
 where `static_score` is the score of the static validation test case if it exists, and 0 if not,
 and `N` is the number of test cases in the group.
 


### PR DESCRIPTION
Flattens test_group.yaml by removing the `scoring` and `static_validation` maps.

Fixes #461 
