### PR TITLE
LaTeX \problemname: change "must" to "should", consistent with the Name section

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -191,7 +191,7 @@ Value           | Incompatible with           | Comments
 ### Name
 
 The name of the problem in each language for which a problem statement exists.
-Each name should not contain any LaTeX formatting, as it will be used in places where judge system does not support LaTeX rendering.
+Each name should not contain any LaTeX formatting, as it will be used in places where the judge system does not support LaTeX rendering.
 The `name` field is a map with the language codes as keys and the problem names as values.
 If there is only one language **and** that language is English, the `name` field can simply be the problem name instead.
 The set of languages for which `name` is given must **exactly** match the set of languages for which a [problem statement](#problem-statements) exists.
@@ -461,7 +461,7 @@ It shall also provide the following commands:
   If it is missing, the `name` value from `problem.yaml` matching the problem statement's language is used.
   If it is present, it is used instead, and must be a LaTeX-formatted version of the `name` value from `problem.yaml` matching the problem statement's language.
   In particular, this should be used if the problem name contains math formulas or other text that should be typeset using LaTeX. Also note that the field `name`
-  from `problem.yaml` must never contain LaTeX, as it will be used in places where the judge system does not support LaTeX rendering.
+  from `problem.yaml` should not contain any LaTeX formatting, as it will be used in places where the judge system does not support LaTeX rendering.
 - `\illustration{width}{filename}{caption}`, a convenience command for adding a figure to the problem statement.
   `width` is a floating-point argument specifying the width of the figure as a fraction of the total width of the problem statement;
   `filename` is the image to display, and `caption`, the text to include below the figure.


### PR DESCRIPTION
Follow-up of #455, looks like there was one more occurrence of "must" that should be changed to "should" :slightly_smiling_face: 