### PR TITLE
More consistent style choice in table description

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -638,8 +638,8 @@ For each test case:
     - any error messages (stderr),
     - the illustration created by the output visualizer (if applicable),
     - the expected output.
-- A _hint_ provides feedback for solving a test case to, e.g., somebody whose submission didn't pass.
-- A _description_ conveys the purpose of a test case.
+- A `hint` provides feedback for solving a test case to, e.g., somebody whose submission didn't pass.
+- A `description` conveys the purpose of a test case.
   It is an explanation of what aspect or edge case of the solution the input file is meant to test.
 
 ### Illustrations


### PR DESCRIPTION
Tiny change. IMO, it becomes easier to read if we format `hint` and `description` in the same way as `input_validator_args`, instead of using _hint_.