### PR TITLE
Disallow pass-fail problems specifying scoring keys

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1269,6 +1269,7 @@ Compile or run-time errors in the visualizer are not judge errors. The return va
 ### Pass-Fail Problems
 
 For pass-fail problems, the verdict of a submission is accepted if and only if every test case in `sample`, `secret`, and any [test data groups](#test-data-groups) are accepted.
+Pass-fail problems may not specify `max_score`, `score_aggregation` or `require_pass`.
 
 ### Scoring Problems
 


### PR DESCRIPTION
Disallowing `require_pass` might be slightly controversial, as it isn't *incorrect* to specify; however, it is a no-op, and might keep people from shooting themselves in the foot. A contrived scenario I can think of is that someone thinks it's equivalent to symlinking all testcases, which then gives unintended behavior if the `output_validator_flags` differ between the groups.