### PR TITLE
Explain that by default, test groups need to have a max score specified

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1304,7 +1304,7 @@ The default value of `require_pass` is an empty sequence.
 For `secret`, all test data groups with `sum` or `min` aggregation, and every test case in a group with `sum` or `min` aggregation, there is a maximum possible score.
 The default value of `max_score` for `secret` is 100.
 The default value of `max_score` for test data groups is `unbounded`.
-Test data groups may only have `unbounded` maximum score if `secret` is unbounded.
+Test data groups may only have `unbounded` maximum score if `secret` is unbounded. (Note that as a consequence, for the default `secret` configuration with a `max_score` of 100, every test data group of `secret` needs to specify a non-default `max_score`.)
 
 The maximum score of a test case in a group with `min` aggregation is `max_score` for the test group.
 The maximum score of a test case in a group with `sum` aggregation is `(max_score - static_validation_score) / N`,


### PR DESCRIPTION
To avoid potential misunderstanding/surprise when reading the spec.