### PR TITLE
Allow underscores and periods at start of file name (but no period at start of test cases or programs)

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -25,10 +25,11 @@ unless it is indicated as meant to be shared with those attempting to solve the 
   Alternatively, the package can be a ZIP-compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
 - All file names for files included in the package must match the regexp
   ```regex
-  ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,253}[a-zA-Z0-9]$
+  ^[a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,253}[a-zA-Z0-9]$
   ```
   i.e., they must be of length at least 2, at most 255, consist solely of lower- or uppercase letters a–z, A–Z, digits 0–9, period, dash, or underscore,
-  but must not begin or end with a period, dash, or underscore.
+  but must not begin with a dash or end with a period, dash, or underscore.
+- Auxiliary files beginning with a period (such as `.gitignore`) are allowed in the problem package for convenience when interoperating with external tools. However, no test case or single-file [program](#program) may begin with a period.
 - All directory names inside the package must match the regexp
   ```regex
   ^[a-zA-Z0-9]([a-zA-Z0-9_-]{0,253}[a-zA-Z0-9])?$


### PR DESCRIPTION
Fixes https://github.com/Kattis/problem-package-format/issues/453

(Based on my interpretation of the consensus there.)