### PR TITLE
Specify output visualizers for multipass and interactive

### DIFF
--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1272,7 +1272,7 @@ Note that the visualizer would not typically be invoked by the judging system, t
 An output visualizer is an optional [program](#programs) that is run after every invocation of the output validator in order to generate images illustrating the submission output.
 An output visualizer program must be an application (executable or interpreted) capable of being invoked with a command line call. It is invoked using the same arguments as the output validator, except that `output_validator_args` is replaced with `output_visualizer_args`.
 It must be provided as a program (as specified [above](#programs)) in the directory `output_visualizer/`. 
-If the problem type is `interactive`, the command line argument `team_output` will be an empty file.
+If the problem type is `interactive`, the file `team_output` passed via stdin will be an empty file.
 If the problem type is `multi-pass` but not `interactive`, then `team_output` will contain the output of the submission from the last pass.
 Note that the `input_file` will not be adjusted for either `interactive` or `multi-pass` problems; it will be the `.in` file of the test case.
 


### PR DESCRIPTION
Closes #437.

The rationale behind these choices are to keep it as simple as possible for the implementer: in many cases, it's infeasible for the judge to pass the required data without breaking backwards compatibility. So we might as well make it as pain-free as possible to increase adoption.