### PR TITLE
Revert changes from #492 (naming restrictions for test data groups)

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -599,6 +599,9 @@ For example, the test data group defined by the directory `data/secret/group1` h
 The test data groups themselves can contain directories, but not further groups.
 This means that there are no `test_group.yaml` further down in the directory hierarchy.
 
+A directory must not have the same name as a test case in the same directory.
+For example, if the file `data/secret/group1/huge.in` exists then the directory `data/secret/group1/huge/` must not, and vice versa.
+
 Each test data group must contain at least one test case, or a static validation test case.
 
 ### Input


### PR DESCRIPTION
Revert changes from #492 regarding naming restrictions for test data groups and test cases.

Following the discussion in #480, we agreed to reinstate these restrictions.

This closes #480.