### PR TITLE
Update problem_format_version to 2025-09 in multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ sort: 1
 This site contains the specification for the Kattis Problem Package Format.
 There are currently three versions:
 
-- The latest (draft) version: <https://www.kattis.com/problem-package-format/spec/2025-09.html>.
+- The latest (release candidate) version: <https://www.kattis.com/problem-package-format/spec/2025-09.html>.
 - The current version: <https://www.kattis.com/problem-package-format/spec/legacy.html>.
 - The ICPC subset of the current version: <https://icpc.io/problem-package-format/spec/legacy-icpc.html>.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ sort: 1
 This site contains the specification for the Kattis Problem Package Format.
 There are currently three versions:
 
-- The latest (draft) version: <https://www.kattis.com/problem-package-format/spec/2023-07-draft.html>.
+- The latest (draft) version: <https://www.kattis.com/problem-package-format/spec/2025-09.html>.
 - The current version: <https://www.kattis.com/problem-package-format/spec/legacy.html>.
 - The ICPC subset of the current version: <https://icpc.io/problem-package-format/spec/legacy-icpc.html>.
 

--- a/appendix/directory_structure.md
+++ b/appendix/directory_structure.md
@@ -6,7 +6,7 @@ sort: 5
 
 # Directory structure
 
-These examples are for the latest version of the spec, `2023-07-draft`.
+These examples are for the latest version of the spec, `2025-09`.
 
 ```text
 <short_name>/

--- a/examples/problem.yaml.md
+++ b/examples/problem.yaml.md
@@ -7,7 +7,7 @@ permalink: /examples/problem_yaml
 ## Minimal
 
 ```yaml
-problem_format_version: 2023-07-draft
+problem_format_version: 2025-09
 name: Sample problem
 uuid: b9f846aa-c233-45ee-a70a-473aecc8fe77
 source: ICPC Mid-Atlantic Regional Contest
@@ -18,7 +18,7 @@ rights_owner: ICPC
 ## Typical
 
 ```yaml
-problem_format_version: 2023-07-draft
+problem_format_version: 2025-09
 name: Sample problem
 uuid: 7594abe6-08e3-4743-8cf9-15c4693cdbf5
 author: John von Judge
@@ -33,7 +33,7 @@ validation: custom
 ## Maximal
 
 ```yaml
-problem_format_version: 2023-07-draft
+problem_format_version: 2025-09
 name:
   en: Sample problem
   nl: Voorbeeld probleem

--- a/examples/problems/interactive/problem.yaml
+++ b/examples/problems/interactive/problem.yaml
@@ -1,4 +1,4 @@
-problem_format_version: 2023-07-draft # or `legacy` for the previous version of the Problem Package Format
+problem_format_version: 2025-09 # or `legacy` for the previous version of the Problem Package Format
 type: pass-fail interactive
 name: Sample problem
 uuid: 117b564d-429b-44d4-bf8c-c264a3703e07

--- a/examples/problems/maximal/problem.yaml
+++ b/examples/problems/maximal/problem.yaml
@@ -1,4 +1,4 @@
-problem_format_version: 2023-07-draft # or `legacy` for the previous version of the Problem Package Format
+problem_format_version: 2025-09 # or `legacy` for the previous version of the Problem Package Format
 type: pass-fail
 name: # May be just a string if there's only a problem statement for one language
   en: Sample Problem

--- a/examples/problems/multipass/problem.yaml
+++ b/examples/problems/multipass/problem.yaml
@@ -1,4 +1,4 @@
-problem_format_version: 2023-07-draft # or `legacy` for the previous version of the Problem Package Format
+problem_format_version: 2025-09 # or `legacy` for the previous version of the Problem Package Format
 type: pass-fail multi-pass
 name: Sample problem
 uuid: c0c117b7-c70c-4369-b574-06e7802beb9f

--- a/examples/problems/passfail/problem.yaml
+++ b/examples/problems/passfail/problem.yaml
@@ -1,4 +1,4 @@
-problem_format_version: 2023-07-draft
+problem_format_version: 2025-09
 type: pass-fail
 name: Sample problem
 uuid: 789c94bb-11e7-47f4-bfe6-4988f460f021

--- a/examples/problems/scoring/problem.yaml
+++ b/examples/problems/scoring/problem.yaml
@@ -1,4 +1,4 @@
-problem_format_version: 2023-07-draft
+problem_format_version: 2025-09
 type: scoring
 name: Sample Scoring problem
 uuid: db3e1e32-dd6f-4158-8f9f-909a383fe8d5

--- a/examples/problems/submit_answer/problem.yaml
+++ b/examples/problems/submit_answer/problem.yaml
@@ -1,4 +1,4 @@
-problem_format_version: 2023-07-draft
+problem_format_version: 2025-09
 type: pass-fail submit-answer
 name: Sample problem
 uuid: 9b3df34b-165a-4ed6-8248-4cee2bd6985c


### PR DESCRIPTION
The current link on https://www.kattis.com/problem-package-format/ is linked to https://www.kattis.com/problem-package-format/spec/2023-07-draft.html which does not exist anymore. 

I updated it to the current version (2025-09), as well as the version in the example problems, and directory_structure.md. 


Since the current Problemtools doesn't support 2025-09 yet, I am unsure if we would like to change that in the examples yet. I could revert those changes if requested.

