### PR TITLE
Backport filename fix from #494 to legacy

### DIFF
--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -18,12 +18,15 @@ used for distributing and sharing problems for algorithmic programming contests 
 - The package must consist of a single directory containing files as described below.
   The directory name must consist solely of lowercase letters a–z and digits 0–9.
   Alternatively, the package can be a ZIP-compressed archive of such a directory with identical base name and extension `.kpp` or `.zip`.
-- All file names for files included in the package must match the regexp
+- All file and directory names included in the package must match the regexp
   ```regex
-  ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,253}[a-zA-Z0-9]$
+  ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,254}$
   ```
-  i.e., they must be of length at least 2, at most 255, consist solely of lower- or uppercase letters a–z, A–Z, digits 0–9, period, dash, or underscore,
-  but must not begin or end with a period, dash, or underscore.
+  that is, they must be of length at least 1, at most 255, consist solely of lower- or uppercase letters a–z, A–Z, digits 0–9, period, dash, or underscore,
+  but must not begin with a dash or period.
+- Auxiliary files and directories beginning with a dash or period (such as `.gitignore` and `.git/`) or containing invalid characters are allowed in the problem package for convenience when interoperating with external tools.
+  However, the judging system shall behave as if all such files and directories were removed before the system interacts with the package.
+  Package preparation tools are encouraged to warn the user if a file or folder that is ignored in this way appears intended as a test case, submission, or other file integral to the package.
 - All text files for a problem must be UTF-8 encoded and not have a byte-order mark (BOM).
 - All text files must have Unix-style line endings (newline/LF byte only).
   Note that LF is line-ending and not line-separating in POSIX, which means that all non-empty text files must end with a newline.


### PR DESCRIPTION
The regular expressions for allowed file and directory names turned out to be overly restrictive when actually implemented. This was addressed for 2025-09 in #494 . This PR backports the same changes to legacy, as the same problems with leading dots and underscores exist there, and it is still the current version of the standard.

I intentionally also copied the language from 2025-09 making the regexp apply to both file and directory names. Earlier, only file names had a regexp in legacy.