### PR TITLE
Add redirect from 2023-07 to 2025-09

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ remote_theme: kattis/jekyll-rtd-theme
 
 plugins:
   - jekyll-remote-theme
+  - jekyll-redirect-from
 
 markdown: CommonMarkGhPages
 commonmark:

--- a/spec/2023-07-draft.md
+++ b/spec/2023-07-draft.md
@@ -1,0 +1,6 @@
+---
+redirect_to: /spec/2025-09.html
+hidden: true
+---
+
+The work-in-progess problem package version 2023-07-draft has been completed and changed to 2025-09.


### PR DESCRIPTION
Title. Merging this should be synced with merging https://github.com/Kattis/jekyll-rtd-theme/pull/2, otherwise we can't hide `2023-07-draft` from the sidebar.