### PR TITLE
Remove multiple graders from legacy

### DIFF
--- a/spec/legacy-icpc.md
+++ b/spec/legacy-icpc.md
@@ -61,7 +61,7 @@ In the case that a program is a single file, it is treated as if a directory wit
 The name of the program, for the purpose of referring to it within the package, is the base name of the file or the name of the directory.
 There can't be two programs of the same kind with the same name.
 
-Validators and graders, but not submissions,
+Input and output validators, but not submissions,
 in the form of a directory may include two POSIX-compliant shell scripts, `build` and `run`.
 These scripts must be executable when they exist or get generated.
 If at least one of these two files is included:

--- a/spec/legacy.md
+++ b/spec/legacy.md
@@ -526,7 +526,8 @@ This information may be displayed to the user upon invocation of the validator.
 ## Graders
 
 Graders are programs that are given the sub-results of a test data group and aggregate a result for the group.
-They are provided in `graders/`.
+There may exist at most one grader program, and it is provided in the `graders/` directory.
+It is a judge error to use `grading: custom` without providing a grader.
 
 For pass-fail problems, this grader will typically just set the verdict to accepted if all sub-results in the group were accepted and otherwise select the "worst" error in the group (see below for definition of "worst"),
 though it is possible to write a custom grader which e.g. accepts if at least half the sub-results are accepted.


### PR DESCRIPTION
Closes #529. 

Also does some cleanup: there is a single reference to graders in ICPC-legacy, which I decided to just remove, since they are never defined. Also specify that using `grading: custom` without providing a grader is judge error, but maybe that's just saying that water is wet.

