### PR TITLE
Specify limits for output visualizers and some recommendations

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -1431,11 +1431,10 @@ If a system does not support displaying multiple image files, then it should dis
 or alternatively the last image file according to lexicographical order.
 
 Compile or run-time errors in the visualizer are not judge errors.
-The return value and any data written by the visualizer to standard error or standard output are ignored.
-Judge systems may impose limits on the output visualizer's usage of resources, including runtime, memory or the amount of output written to stdout.
+The return value and any data written by the visualizer to standard error do not carry special meaning and may be ignored.
+Judge systems may impose limits on the output visualizer's usage of resources, as described in [Resource guarantees](#resource-guarantees).
 Exceeding any of these limits is not a judge error.
-It is recommended that the judge system allows the output visualizer at least 5 seconds of runtime.
-To avoid timeouts, it is advisable to limit the output size, as the input to the visualizer is typically user-controlled.
+To avoid exceeding any of the resource limits, it is advisable to limit the output size, as the input to the visualizer is typically somewhat user-controlled.
 
 When writing an output visualizer, one should take care to ensure that it is portable.
 In particular:

--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -1411,7 +1411,8 @@ Note that the visualizer would not typically be invoked by the judging system, t
 ## Output visualizer
 
 An output visualizer is an optional [program](#programs) that is run after every invocation of the output validator in order to generate images illustrating the submission output.
-An output visualizer program must be an application (executable or interpreted) capable of being invoked with a command line call. It is invoked using the same arguments as the output validator, except that `output_validator_args` is replaced with `output_visualizer_args`.
+An output visualizer program must be an application (executable or interpreted) capable of being invoked with a command line call.
+It is invoked using the same arguments as the output validator, except that `output_validator_args` is replaced with `output_visualizer_args`.
 It must be provided as a program (as specified [above](#programs)) in the directory `output_visualizer/`. 
 If the problem type is `interactive`, the file `team_output` passed via stdin will be an empty file.
 If the problem type is `multi-pass` but not `interactive`, then `team_output` will contain the output of the submission from the last pass.
@@ -1429,7 +1430,20 @@ It is recommended to use zero-padded integers as prefixes of ids to ensure corre
 If a system does not support displaying multiple image files, then it should display `teamimage.<ext>` (or `judgeimage.<ext>`), if it exists,
 or alternatively the last image file according to lexicographical order.
 
-Compile or run-time errors in the visualizer are not judge errors. The return value and any data written by the visualizer to standard error or standard output are ignored.
+Compile or run-time errors in the visualizer are not judge errors.
+The return value and any data written by the visualizer to standard error or standard output are ignored.
+Judge systems may impose limits on the output visualizer's usage of resources, including runtime, memory or the amount of output written to stdout.
+Exceeding any of these limits is not a judge error.
+It is recommended that the judge system allows the output visualizer at least 5 seconds of runtime.
+To avoid timeouts, it is advisable to limit the output size, as the input to the visualizer is typically user-controlled.
+
+When writing an output visualizer, one should take care to ensure that it is portable.
+In particular:
+- Avoid using precompiled binary libraries or executables, such as FFmpeg.
+- Avoid languages not guaranteed to be present, such as Java.
+- Avoid relying on libraries not included in the standard library, such as Pillow.
+
+To generate `png`, `jpg` or `jpeg` files, it is recommended to use an image-writing library that is not precompiled. 
 
 ## Result aggregation
 


### PR DESCRIPTION
Closes #530 and #531.

The part about portability is of course highly subjective, but I think we can all agree that we should try to strive to make problem packages portable for the foreseeable future?

We should probably create a concrete example in `examples`. I tried using [std_image_write.h](https://github.com/nothings/stb/blob/master/stb_image_write.h), and it seems to work well.

I used it as a basis for timing: 5 seconds seems to be plenty of time.
Here's the output of timing, running single-threaded on 3.6GHz processor (Intel i5-8600K), running on WSL, compiled with gcc and O2. Compilation time with minimal standard library includes is ~350ms, which is not bad at all (the effect of a single `#include <bits/stdc++.h>` is much greater). I chose .jpg quality level 90.
[Code for test](https://gist.github.com/Matistjati/2b80b18732a6b619d7a7efc058eff609)
```
  14x  14  of noise     with format .jpg took 0ms
31  x31    of noise     with format .jpg took 0ms
70  x70    of noise     with format .jpg took 0ms
158 x158   of noise     with format .jpg took 2ms
353 x353   of noise     with format .jpg took 10ms
790 x790   of noise     with format .jpg took 50ms
1767x1767  of noise     with format .jpg took 240ms
3952x3952  of noise     with format .jpg took 1185ms
8838x8838  of noise     with format .jpg took 5928ms
****
14  x14    of gradient  with format .jpg took 454ms
31  x31    of gradient  with format .jpg took 0ms
70  x70    of gradient  with format .jpg took 0ms
158 x158   of gradient  with format .jpg took 0ms
353 x353   of gradient  with format .jpg took 2ms
790 x790   of gradient  with format .jpg took 12ms
1767x1767  of gradient  with format .jpg took 58ms
3952x3952  of gradient  with format .jpg took 277ms
8838x8838  of gradient  with format .jpg took 1348ms
19764x19764  of gradient  with format .jpg took 6780ms
****
14  x14    of noise     with format .png took 0ms
31  x31    of noise     with format .png took 4ms
70  x70    of noise     with format .png took 5ms
158 x158   of noise     with format .png took 6ms
353 x353   of noise     with format .png took 151ms
790 x790   of noise     with format .png took 167ms
1767x1767  of noise     with format .png took 751ms
3952x3952  of noise     with format .png took 3802ms
****
14  x14    of gradient  with format .png took 287ms
31  x31    of gradient  with format .png took 0ms
70  x70    of gradient  with format .png took 0ms
158 x158   of gradient  with format .png took 1ms
353 x353   of gradient  with format .png took 7ms
790 x790   of gradient  with format .png took 38ms
1767x1767  of gradient  with format .png took 148ms
3952x3952  of gradient  with format .png took 741ms
8838x8838  of gradient  with format .png took 3756ms
****
```
Where gradient looks something like this
<img width="611" height="572" alt="image" src="https://github.com/user-attachments/assets/b93dd612-ad0b-4aa4-bffd-e6a70606ca2f" />


And noise like this
<img width="1186" height="775" alt="image" src="https://github.com/user-attachments/assets/004958f2-cea7-4ea5-b813-1df30a685c2d" />
