### PR TITLE
Clarify test data section

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -537,9 +537,9 @@ Directory              | Described In                      | Description
 ---------------------- | --------------------------------- | -----------
 `data/sample/`         | [Samples and full feedback](#samples-and-full-feedback) | Sample test data
 `data/secret/`         | [Test cases](#test-cases)         | Secret test data
-`data/invalid_input/`  | [Invalid input](#invalid-input)   | Inputs that must be rejected by input validator. 
-`data/invalid_output/` | [Invalid output](#invalid-output) | Outputs that must be rejected by output validator.
-`data/valid_output/`   | [Valid output](#valid-output)     | Outputs that must be accepted by output validator.
+`data/invalid_input/`  | [Invalid input](#invalid-input)   | Inputs that must be rejected by at least one input validator. 
+`data/invalid_output/` | [Invalid output](#invalid-output) | Outputs that must be rejected by the output validator.
+`data/valid_output/`   | [Valid output](#valid-output)     | Outputs that must be accepted by the output validator.
 
 The `secret` directory must exist, and contain either some test cases, or some [test data groups](#test-data-groups), but not both.
 All other directories are optional.


### PR DESCRIPTION
General rewording and restructuring of test data section.

- Collect the "validation" test cases together.
- Move the test data group description earlier.
- Change all "test group" to "test data group" (Progress on #523)
- Change "folder" to "directory" (Closes #521)
- List all allowed files in test cases (Closes #505)
- Move description of statement and download overrides into test data section.
- Clarify that secret can have groups or test cases (and/or directories), but not both, and groups are defined by `test_group.yaml` (Progress on #499)
- Tried to use test case consistently (Closes #522)
   
Note that this ended up requiring a `.in.download` and a `.ans.download` file if you use a `.interaction` file. This is not what we discussed, and maybe not what we wanted, but it kinda logically follows from the rest.
