### PR TITLE
Clarify that non-group directories are allowed.

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -541,7 +541,7 @@ Directory              | Described In                      | Description
 `data/invalid_output/` | [Invalid output](#invalid-output) | Outputs that must be rejected by the output validator.
 `data/valid_output/`   | [Valid output](#valid-output)     | Outputs that must be accepted by the output validator.
 
-The `secret` directory must exist, and contain either some test cases, or some [test data groups](#test-data-groups), but not both.
+The `secret` directory must exist, and contain either some test cases (possibly organized in directories), or some [test data groups](#test-data-groups), but not both.
 All other directories are optional.
 
 ### Test cases 
@@ -585,7 +585,8 @@ Remember that the numbered prefixes should be zero padded to the same length to 
 The secret data may be subdivided into test data groups.
 Every subdirectory of `data/secret/` that contains a `test_group.yaml` configuration file is a test data group.
 There can only be test data groups *or* test cases in `data/secret`, never both.
-That is, if there are any groups in `data/secret/` then there must not be any `.in` files directly in `data/secret/` nor any subdirectories that are not groups, and vice versa.
+If there are any test data groups in `data/secret/`, then there must not be any `.in` files directly in `data/secret/`, and every subdirectory of `data/secret/` must be a test data group.
+If there are no test data groups, `data/secret/` may contain test cases both directly and within subdirectories (which are then not test data groups since they lack `test_group.yaml`).
 The name of a test data group is the path under `data/`.
 For example, the test data group defined by the configuration file `data/secret/group1/test_group.yaml` has the name `secret/group1`.
 


### PR DESCRIPTION
Make it clear that it is *not* allowed to mix groups and test cases, but that test cases can always be organized in (non-group) directories.

Closes #499 