### PR TITLE
Add multiple output visualizations as sequential steps.

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -1300,8 +1300,15 @@ Note that the `input_file` will not be adjusted for either `interactive` or `mul
 
 All files written to the feedback directory by the output validator are accessible to the visualizer. 
 If the output visualizer does not have sufficient data to generate an adequate visualization using only the command line arguments, the output validator should write the necessary data to the feedback directory (see [Reporting additional feedback](#reporting-additional-feedback)).
-The visualizer may overwrite or create image files in the feedback directory with the name `teamimage.ext` or `judgeimage.ext`, where `ext` is one of: `png`, `jpg`, `jpeg`, or `svg`.
+The visualizer may overwrite or create image files in the feedback directory with the name `teamimage.<ext>` or `judgeimage.<ext>`, where `<ext>` is one of: `png`, `jpg`, `jpeg`, or `svg`.
 It must not write to `score.txt`, `teammessage.txt`, or any other files in the feedback directory other than those of the form `teamimage.ext` or `judgeimage.ext`.
+
+The visualizer may output multiple image files with the purpose of visualizing the submission output in sequential steps.
+The names must match `teamimage-<id>.<ext>` or `judgeimage-<id>.<ext>`, where `<id>` is an identifying string for the image.
+The images should be displayed in lexicographical order by filename.
+It is recommended to use zero-padded integers as prefixes of ids to ensure correct ordering.
+If a system does not support displaying multiple image files, then it should display `teamimage.<ext>` (or `judgeimage.<ext>`), if it exists,
+or alternatively the last image file according to lexicographical order.
 
 Compile or run-time errors in the visualizer are not judge errors. The return value and any data written by the visualizer to standard error or standard output are ignored.
 


### PR DESCRIPTION
Perhaps zero padded integers are sufficient as IDs.
I had this thought that the steps might be accompanied by some minimal description.