### PR TITLE
Move sample to statement

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -463,7 +463,8 @@ When a test case is shared after the solver failed on the test case, the followi
 
   - the produced output (stdout), 
   - any error messages (stderr),
-  - the illustration created by the output visualizer (if applicable).
+  - any [feedback message](#reporting-additional-feedback) from the output validator (`teammessage.txt`)
+  - the [feedback illustration](#output-visualizer) from the output visualizer (`teammessage.<ext>`).
 
 #### Samples for interactive and multi-pass problems
 


### PR DESCRIPTION
Should not change the meaning of anything.

Moving the description on how samples (and `full_feedback`) are displayed and downloaded to the problem statement section, since it's more related to how to communicate with solvers, then on how judge systems should run tests.

Closes #544 