### PR TITLE
Add templates to attachments, don't allow other directories

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -510,7 +510,28 @@ Additionally, the following extensions shall be supported:
 ## Attachments
 
 Public (non-secret) files provided in addition to the problem statement and sample test data belong in the `attachments/` directory.
-One example of such files are testing tools.
+One example of such a file is a testing tool.
+
+All files directly in `attachments/` should be made available to solvers.
+How this is done is not specified by the problem format; it could be to make them available for download, copy them to a known location on disk, or something else entirely.
+Directories in `attachments/` should not be made available directly, but instead handled as specified in the table below.
+It is an error to have a directory in `attachments/` that is not listed below.
+If an attachment needs an internal directory structure, it should be zipped, and the zip file attached instead.
+A system may optionally unpack any zip file before making it available.
+
+Directory                | Described in                      | Description
+------------------------ | --------------------------------- | -----------
+`attachments/templates/` | [Code templates](#code-templates) | Code templates.
+
+### Code templates
+
+The directory `attachments/templates/` contains template code to be provided to the solver.
+
+Code templates for a specific language are provided in the non-empty directory `attachments/templates/<language>/`, where `<language>` is a language code as given in the [languages table](../appendix/languages.md).
+Code templates for languages without a language-specific directory are optionally provided in the non-empty directory `attachments/templates/default/`.
+
+If a system provides a code editor, the code templates should be preloaded.
+Otherwise, they should be provided in some other way, possibly as ordinary attachments.
 
 ## Solution description
 


### PR DESCRIPTION
General rule is that attachments can't have directories.
Define special directory for templates.

Closes #547
Closes #548 