### PR TITLE
Add links to where constants are replaced

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -407,11 +407,11 @@ where `name` is one of the names defined in `constants`.
 Tags {% raw %}`{{xyz}}`{% endraw %} containing a name that is not defined are not modified but may be warned for.
 
 All constant sequences in the following files will be replaced by the value of the corresponding constant:
-- Markdown problem statements
-- input and output validators
-- included code
-- example submissions
-- `test_group.yaml`
+- [Markdown](#markdown-environment-and-supported-features) problem statements
+- [input](#input-validators) and [output](#output-validator) validators
+- [included files](#included-files)
+- [example submissions](#example-submissions)
+- [`test_group.yaml`](#test-data-configuration)
 
 Note that constants are also available in LaTeX problem statements via the dedicated command `\constant{name}`.
 


### PR DESCRIPTION
Add links to constant description (and fix name of included files).

Closes #556 