### PR TITLE
Do not assume determinism

### DIFF
--- a/spec/2025-09.md
+++ b/spec/2025-09.md
@@ -752,11 +752,8 @@ Extension                       | Described in                                  
 `.yaml`                         | [Test case configuration](#test-case-configuration) | Additional configuration of the test case
 `.png`, `.jpg`, `.jpeg`, `.svg` | [Illustrations](#illustrations)                     | Illustration of the test case
 
-Judge systems may assume that the result of running a program on a test case is deterministic.
-For any two test cases, if the contents of their `.in` and `.files` directory are equivalent,
-as well as the `args` sequence in the `.yaml` file, then the input of the two test cases is equivalent.
-For any two test cases, if their input, output validator arguments and the contents of their `.ans` files are equivalent, then the test cases are equivalent.
-The assumption of determinism means that a judge system could choose to reuse the result of a previous run, or to re-run the equivalent test case.
+Judge systems may not assume that the result of running a program on a test case is deterministic.
+The assumption of non determinism means that a judge system cannot choose to reuse the result of a previous run.
 
 Test cases and [test data groups](#test-data-groups) will be used in lexicographical order on test case or test data group name.
 It is good practice to use a numbered prefix such as `00`, `01`, `02`, `03`, and so on, to get the desired order of test cases, while keeping the file names descriptive.


### PR DESCRIPTION
The assumption of determinism was added to the new spec in af7ac805a6fc202593e0879924fd811f72feb7cd, but I think this it is a mistake. It breaks backwards compatibility and also breaks the assumptions of all kinds of user groups.

First of: non deterministic submissins do exists and are also sometimes required. The assumption of determinism clearly breaks such randomized problems in one way or another.

1. The fact whether or not results are reused can heavily influence the acceptance probability for submissions in various ways:
    - a problem setter may assume that dublicate test cases can be used to reduce the acceptance probability
    - a participant who knows that result are reused might get an advantage because he knows that his submission only fails on test cases
    - a participant who does not know this would resubmit his time/hadware seeded submission expecting it to be rejudged
    - No user group can actually be sure whether or not results are reused...
2. This assumption did not exist in legacy
    - This will confuse problem setters
    - This is an issue when upgrading problems
3. This makes problems with randomized inputs impossible
    - https://open.kattis.com/problems/evolutionaryexcerpt